### PR TITLE
Remove scheduled cron runs; restrict test workflows to main + manual dispatch

### DIFF
--- a/.github/workflows/adapter-certification.yml
+++ b/.github/workflows/adapter-certification.yml
@@ -2,9 +2,12 @@ name: Adapter Certification
 
 # Certify adapter compatibility with Interlock Class III / IV / V
 on:
-  schedule:
-    # Run weekly on Sunday at 5 AM UTC
-    - cron: '0 5 * * 0'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       adapter:

--- a/.github/workflows/adapter-stability.yml
+++ b/.github/workflows/adapter-stability.yml
@@ -2,9 +2,12 @@ name: Adapter Stability Tests
 
 # Long-run stability validation for each adapter (≥50 cycles)
 on:
-  schedule:
-    # Run weekly on Saturday at 4 AM UTC
-    - cron: '0 4 * * 6'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       adapter:

--- a/.github/workflows/adapter-stress-test.yml
+++ b/.github/workflows/adapter-stress-test.yml
@@ -2,9 +2,12 @@ name: Adapter Stress Tests
 
 # Run stress tests against each adapter to validate survival and protection
 on:
-  schedule:
-    # Run daily at 3 AM UTC
-    - cron: '0 3 * * *'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       adapter:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,9 +2,12 @@ name: Benchmark Suite
 
 # Run weekly benchmarks to track performance and regression
 on:
-  schedule:
-    # Run every Sunday at midnight UTC
-    - cron: '0 0 * * 0'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       benchmark_seed:

--- a/.github/workflows/competitive-benchmark.yml
+++ b/.github/workflows/competitive-benchmark.yml
@@ -2,9 +2,12 @@ name: Competitive Benchmark
 
 # Run competitive benchmarks: Interlock vs alternatives
 on:
-  schedule:
-    # Run weekly on Sundays at 3 AM UTC
-    - cron: '0 3 * * 0'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       stress_multiplier:

--- a/.github/workflows/production-demo.yml
+++ b/.github/workflows/production-demo.yml
@@ -2,9 +2,12 @@ name: Production Demo
 
 # Comprehensive production simulation comparing Interlock vs unprotected
 on:
-  schedule:
-    # Run weekly on Sunday at 4 AM UTC
-    - cron: '0 4 * * 0'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/production-monitor.yml
+++ b/.github/workflows/production-monitor.yml
@@ -2,6 +2,12 @@ name: Production Evidence Collection
 
 # Simulate production workload and collect evidence of Interlock protection
 on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       workload_scenario:
@@ -18,9 +24,6 @@ on:
         description: 'Duration of simulation (minutes)'
         required: false
         default: '30'
-  schedule:
-    # Run weekly on Wednesdays at 3 AM UTC
-    - cron: '0 3 * * 3'
 
 # Only run one production simulation at a time
 concurrency:

--- a/.github/workflows/real-faiss-validation.yml
+++ b/.github/workflows/real-faiss-validation.yml
@@ -2,9 +2,12 @@ name: Real FAISS Validation
 
 # Validates Interlock with ACTUAL FAISS operations, not simulations
 on:
-  schedule:
-    # Run weekly on Saturday at 5 AM UTC
-    - cron: '0 5 * * 6'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       vector_count:

--- a/.github/workflows/real-pinecone-test.yml
+++ b/.github/workflows/real-pinecone-test.yml
@@ -2,9 +2,12 @@ name: Real Pinecone Integration Test
 
 # Tests Interlock Pinecone adapter with ACTUAL Pinecone API calls
 on:
-  schedule:
-    # Run weekly on Sunday at 6 AM UTC
-    - cron: '0 6 * * 0'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       vector_count:

--- a/.github/workflows/scale-test.yml
+++ b/.github/workflows/scale-test.yml
@@ -2,9 +2,12 @@ name: Scale Test
 
 # Run scale tests: Test Interlock at enterprise scale
 on:
-  schedule:
-    # Run weekly on Saturdays at 4 AM UTC
-    - cron: '0 4 * * 6'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       vectors:

--- a/.github/workflows/stress-chamber.yml
+++ b/.github/workflows/stress-chamber.yml
@@ -2,11 +2,12 @@ name: Stress Chamber Tests
 
 # Run stress tests daily to validate Interlock protection under extreme load
 on:
-  schedule:
-    # Run daily at 2 AM UTC with medium profile
-    - cron: '0 2 * * *'
-    # Run weekly on Sunday at 3 AM UTC with heavy profile
-    - cron: '0 3 * * 0'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       stability_cycles:
@@ -49,14 +50,7 @@ jobs:
       - name: Determine stress profile
         id: profile
         run: |
-          # Check if this is the weekly Sunday run
-          # date -u +%u returns 1-7 where 1=Monday, 7=Sunday
-          DAY_OF_WEEK=$(date -u +%u)
-          HOUR=$(date -u +%H)
-          
-          if [ "$DAY_OF_WEEK" == "7" ] && [ "$HOUR" == "3" ] && [ "${{ github.event_name }}" == "schedule" ]; then
-            echo "profile=heavy" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event.inputs.stress_profile }}" != "" ]; then
+          if [ "${{ github.event.inputs.stress_profile }}" != "" ]; then
             echo "profile=${{ github.event.inputs.stress_profile }}" >> $GITHUB_OUTPUT
           else
             echo "profile=medium" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Motivation
- Reduce recurring GitHub Actions test frequency to a minimum by removing cron schedules and limiting automatic runs.
- Ensure tests still run on `push` to `main`, on `pull_request` targeting `main`, and when manually triggered via `workflow_dispatch` so badges can be refreshed on demand.
- Keep `workflow_dispatch` inputs so maintainers can manually run heavy or long tests when needed.

### Description
- Removed `schedule`/cron entries and added `push` (branches: `main`) and `pull_request` (branches: `main`) triggers while retaining `workflow_dispatch` in the workflows: `adapter-certification.yml`, `adapter-stability.yml`, `adapter-stress-test.yml`, `benchmark.yml`, `competitive-benchmark.yml`, `production-demo.yml`, `production-monitor.yml`, `real-faiss-validation.yml`, `real-pinecone-test.yml`, `scale-test.yml`, and `stress-chamber.yml`.
- Simplified `stress-chamber.yml` by removing schedule-based logic that selected a weekly heavy profile and now using the `stress_profile` `workflow_dispatch` input or the default `medium` profile.
- Committed the updated workflow files so the next run will follow the new trigger behavior and badges will reflect the most recent run (manual or automated).

### Testing
- No automated CI workflows were executed as part of this change because it only alters workflow triggers and keeps `workflow_dispatch` for manual runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950626f40788324a2fd10b7297c4dfc)