### PR TITLE
Unify enforcement decision schema, add fail-closed/dev-fail-open, streaming guard, and runtime tests

### DIFF
--- a/apps/live-monitor/server.ts
+++ b/apps/live-monitor/server.ts
@@ -151,24 +151,34 @@ app.post('/interlock/decision', (req, res) => {
     const shouldRefuse = adapter.shouldRefuse();
     const confidence = adapter.getConfidence();
 
+    const requestId = req.body?.request_id || `req-${Date.now()}`;
     if (shouldRefuse) {
         res.json({
-            allowed: false,
-            refusal: {
-                reason: "Interlock refusal: Confidence below quality floor",
-                retry_after_ms: 5000,
-                // In generic mode, we might generate ID here or let client handle it.
-                // For now, Brain is authority.
-                incident_id: "remote-" + Date.now(),
-                confidence
-            }
+            decision: {
+                mode: 'ENFORCE',
+                action: 'REFUSE',
+                reason: 'Interlock refusal: Confidence below quality floor',
+                law_hash: 'live-monitor-law',
+                request_id: requestId,
+                action_taken: 'REFUSED',
+                status_code: 503,
+                timestamp: new Date().toISOString()
+            },
+            metadata: { confidence }
         });
     } else {
         res.json({
-            allowed: true,
-            metadata: {
-                confidence
-            }
+            decision: {
+                mode: 'ENFORCE',
+                action: 'ALLOW',
+                reason: 'Policy allows request',
+                law_hash: 'live-monitor-law',
+                request_id: requestId,
+                action_taken: 'ALLOWED',
+                status_code: 200,
+                timestamp: new Date().toISOString()
+            },
+            metadata: { confidence }
         });
     }
 });

--- a/packages/interlock-express/src/index.ts
+++ b/packages/interlock-express/src/index.ts
@@ -1,295 +1,156 @@
 import { Request, Response, NextFunction } from 'express';
-// Relative imports to reuse Core Logic (Monorepo style)
-// In a real published package, these would be in @interlock/core
 import { ConfidenceMonitor } from '../../../adapters/pinecone/confidence_monitor';
 import { LatencyProbe } from '../../../adapters/pinecone/latency_probe';
 import { FailureInjector } from '../../../adapters/pinecone/failure_injector';
-import { FileIncidentSink, IncidentSink, InterlockEvent } from './sink';
+import { FileIncidentSink, IncidentSink } from './sink';
 import { startHealthWindowEmitter, recordRequest, MetricsCollector } from './health-window';
 import { emitInterventionEvent } from './intervention-emitter';
-import { loadLaw, mapLawToHysteresisConfig } from '../../../services/law-loader';
+import { loadLaw } from '../../../services/law-loader';
 import { Domain } from '../../../services/events.types';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+
+export type EnforcementMode = 'ENFORCE' | 'SHADOW_ONLY';
+export type EnforcementAction = 'ALLOW' | 'DEGRADE' | 'REFUSE' | 'BLOCK';
+export interface EnforcementDecision {
+    mode: EnforcementMode;
+    action: EnforcementAction;
+    reason: string;
+    law_hash: string;
+    request_id?: string;
+    stream_id?: string;
+    action_taken: string;
+    status_code: number;
+    timestamp: string;
+}
 
 export interface InterlockOptions {
     dry_run?: boolean;
     quality_floor?: number;
     failure_class?: string;
     incident_file?: string;
-    /** SDE integration: domain for telemetry */
     domain?: Domain;
-    /** SDE integration: enable JSONL telemetry */
     enable_sde_telemetry?: boolean;
 }
 
-// Extend Express Request
-declare global {
-    namespace Express {
-        interface Request {
-            interlock?: {
-                monitor: ConfidenceMonitor;
-                failureInjector: FailureInjector;
-            }
-        }
-    }
-}
-
-// Global state for Hysteresis/Incident Tracking (Per process)
-// Ideally this should be per-instance, but middleware is usually singleton-ish per app.
+declare global { namespace Express { interface Request { interlock?: { monitor: ConfidenceMonitor; failureInjector: FailureInjector; } } } }
 let incidentId = 0;
 let activeIncident: { start: number, events: any[] } | null = null;
 let recoveryWindowStart: number | null = null;
 const RECOVERY_HYSTERESIS_MS = 5000;
-
-// SDE telemetry state
 let metricsCollector: MetricsCollector | null = null;
 let healthWindowStopper: (() => void) | null = null;
+
+function emitEnforcementTelemetry(decision: EnforcementDecision): void {
+    console.log('[Interlock Enforcement]', JSON.stringify(decision));
+}
 
 export function interlockExpress(options: InterlockOptions = {}) {
     const domain: Domain = options.domain || 'ollama';
     const enableSdeTelemetry = options.enable_sde_telemetry ?? true;
-
-    // Load law from disk (SDE integration)
     const lawResult = loadLaw(domain);
-    if (lawResult.warnings.length > 0) {
-        console.log(`[Interlock] Law warnings: ${lawResult.warnings.join(', ')}`);
-    }
-
-    // Use law parameters or options
-    const qualityFloor = lawResult.parameters.confidence_floor || options.quality_floor || 0.5;
+    const qualityFloor = options.quality_floor ?? lawResult.parameters.confidence_floor ?? 0.5;
     const latencyThresholdMs = lawResult.parameters.latency_threshold_ms || 500;
     const errorThresholdPct = lawResult.parameters.error_threshold_pct || 0.05;
-
     const failureClass = options.failure_class || 'Forced application error (non-user, non-network)';
     const logFile = options.incident_file || path.resolve(process.cwd(), 'docs/LIVE_INCIDENTS.md');
     const dryRun = options.dry_run || false;
-
-    // Initialize Core Logic
     const latencyProbe = new LatencyProbe();
     const failureInjector = new FailureInjector();
     const monitor = new ConfidenceMonitor(latencyProbe, failureInjector, qualityFloor, latencyThresholdMs);
     const sink: IncidentSink = new FileIncidentSink(logFile);
 
-    // Start SDE telemetry (health window emitter)
     if (enableSdeTelemetry) {
-        const emitter = startHealthWindowEmitter({
-            domain,
-            thresholds: {
-                latency_threshold_ms: latencyThresholdMs,
-                error_threshold_pct: errorThresholdPct
-            }
-        });
+        const emitter = startHealthWindowEmitter({ domain, thresholds: { latency_threshold_ms: latencyThresholdMs, error_threshold_pct: errorThresholdPct } });
         metricsCollector = emitter.collector;
         healthWindowStopper = emitter.stop;
     }
 
-    console.log(`[Interlock] Middleware initialized. Domain: ${domain}, Quality Floor: ${qualityFloor}, Dry Run: ${dryRun}`);
-    console.log(`[Interlock] Law: ${lawResult.law?.law_id || 'defaults'} (hash: ${lawResult.lawHash})`);
-
     return (req: Request, res: Response, next: NextFunction) => {
-        // --- Dashboard Routes ---
         if (req.path === '/dashboard') {
             const dashboardPath = path.resolve(__dirname, 'dashboard.html');
             if (fs.existsSync(dashboardPath)) {
                 res.setHeader('Content-Type', 'text/html');
                 return res.sendFile(dashboardPath);
-            } else {
-                return res.status(404).send('Dashboard not found (build issue?)');
             }
+            return res.status(404).send('Dashboard not found (build issue?)');
         }
 
         if (req.path === '/interlock/events') {
             const startLine = parseInt(req.query.start as string) || 0;
             const eventsPath = process.env.INTERLOCK_EVENTS_PATH || path.resolve(process.cwd(), 'logs/interlock_events.jsonl');
-
-            if (!fs.existsSync(eventsPath)) {
-                return res.json({ status: 'ok', events: [], nextIndex: 0 });
-            }
-
+            if (!fs.existsSync(eventsPath)) return res.json({ status: 'ok', events: [], nextIndex: 0 });
             try {
-                // Read file slightly inefficiently but safe for demo
-                // Ideally this would use a proper log tailer or keep file handle open
                 const content = fs.readFileSync(eventsPath, 'utf-8');
                 const lines = content.trim().split('\n');
-                const newEvents = lines.slice(startLine).map(line => {
-                    try { return JSON.parse(line); } catch (e) { return null; }
-                }).filter(Boolean);
-
-                return res.json({
-                    status: 'ok',
-                    events: newEvents,
-                    nextIndex: lines.length
-                });
+                const newEvents = lines.slice(startLine).map(line => { try { return JSON.parse(line); } catch { return null; } }).filter(Boolean);
+                return res.json({ status: 'ok', events: newEvents, nextIndex: lines.length });
             } catch (e) {
                 return res.status(500).json({ error: String(e) });
             }
         }
 
-        const startTime = Date.now();
-        // ... rest of middleware ...
+        if (req.path.includes('/stream')) {
+            return res.status(501).json({
+                error: 'Streaming enforcement unsupported without protocol adapter',
+                enforcement_todo: ['SSE/NDJSON fatal event then close', 'WebSocket close code 1008', 'raw/unknown transport abort']
+            });
+        }
 
-        // 3. Response Interception (Metrics) - Attached early to capture all outcomes
+        const startTime = Date.now();
         res.on('finish', () => {
             const duration = Date.now() - startTime;
-            latencyProbe.record({
-                timestamp: Date.now(),
-                latencyMs: duration,
-                operation: 'query'
-            });
-
-            // Record to SDE metrics collector
+            latencyProbe.record({ timestamp: Date.now(), latencyMs: duration, operation: 'query' });
             if (metricsCollector) {
                 const isError = res.statusCode >= 500 && res.statusCode !== 503;
-                recordRequest(metricsCollector, duration, isError);
+                if (!(dryRun && (res.statusCode === 503 || res.statusCode === 429))) recordRequest(metricsCollector, duration, isError);
             }
-
-            // Record Failure (500s)
             if (res.statusCode >= 500 && res.statusCode !== 503) {
-                // 503 is our intentional refusal, not a crash.
-                // 500 is a crash.
-                failureInjector.recordSignal({
-                    timestamp: Date.now(),
-                    type: 'error',
-                    severity: 'high',
-                    message: `HTTP ${res.statusCode}`
-                });
+                failureInjector.recordSignal({ timestamp: Date.now(), type: 'error', severity: 'high', message: `HTTP ${res.statusCode}` });
             }
         });
 
-        // 1. Update Monitor
         monitor.update();
-
-
-        // Attach internals for admin/debug (allow app to trigger failures)
         req.interlock = { monitor, failureInjector };
 
-        // 2. Check Refusal
-        if (monitor.shouldRefuse()) {
-            // Hysteresis / Incident Logic
+        const requestId = (req.headers['x-request-id'] as string) || `req-${Date.now()}`;
+        const decision: EnforcementDecision = monitor.shouldRefuse() ? {
+            mode: dryRun ? 'SHADOW_ONLY' : 'ENFORCE', action: 'REFUSE', reason: 'Interlock refusal: Confidence below quality floor',
+            law_hash: lawResult.lawHash, request_id: requestId,
+            action_taken: dryRun ? 'WOULD_REFUSE' : 'REFUSED', status_code: 503, timestamp: new Date().toISOString()
+        } : {
+            mode: dryRun ? 'SHADOW_ONLY' : 'ENFORCE', action: 'ALLOW', reason: 'Policy allows request', law_hash: lawResult.lawHash,
+            request_id: requestId, action_taken: dryRun ? 'WOULD_ALLOW' : 'ALLOWED', status_code: 200, timestamp: new Date().toISOString()
+        };
+        emitEnforcementTelemetry(decision);
+
+        if (decision.action === 'REFUSE' || decision.action === 'BLOCK' || decision.action === 'DEGRADE') {
             if (!activeIncident) {
                 incidentId++;
                 activeIncident = { start: Date.now(), events: [] };
-                console.log(`[Interlock] 🛡️ Incident #${incidentId} Started`);
-
-                sink.logEvent({
-                    incidentId: String(incidentId).padStart(3, '0'), // Header
-                    trigger: 'Confidence < Quality Floor',
-                    action: 'Traffic Refusal',
-                    details: 'Initial refusal triggered',
-                    recoveryTime: 0,
-                    confidence: monitor.getConfidence(),
-                    failureClass
-                });
-
-                // Emit SDE intervention event
+                sink.logEvent({ incidentId: String(incidentId).padStart(3, '0'), trigger: 'Confidence < Quality Floor', action: 'Traffic Refusal', details: 'Initial refusal triggered', recoveryTime: 0, confidence: monitor.getConfidence(), failureClass });
                 if (enableSdeTelemetry) {
-                    emitInterventionEvent({
-                        domain,
-                        trigger: {
-                            interlockTrigger: 'confidence_floor_breach',
-                            thresholdMs: latencyThresholdMs,
-                            observedMs: latencyProbe.getStats().meanMs || 0,
-                            confidence: monitor.getConfidence()
-                        },
-                        action: {
-                            interlockAction: 'refuse',
-                            priorState: 'closed',
-                            newState: 'open'
-                        },
-                        recovery: {
-                            timeMs: 0,
-                            probeAttempts: 0,
-                            finalState: 'open'
-                        },
-                        context: {
-                            qualityFloorHit: true
-                        }
-                    });
+                    emitInterventionEvent({ domain, trigger: { interlockTrigger: 'confidence_floor_breach', thresholdMs: latencyThresholdMs, observedMs: latencyProbe.getStats().meanMs || 0, confidence: monitor.getConfidence() }, action: { interlockAction: 'refuse', priorState: 'closed', newState: 'open' }, recovery: { timeMs: 0, probeAttempts: 0, finalState: 'open' }, context: { qualityFloorHit: true } });
                 }
             }
-
-            // Reset recovery window if we are still refusing
             recoveryWindowStart = null;
-
-            if (!dryRun) {
-                res.status(503).json({
-                    refused: true,
-                    incident_id: incidentId,
-                    reason: "Interlock refusal: Confidence below quality floor",
-                    retry_after_ms: 5000
-                });
-
-                // Record Failure (Refusal is a form of protection, but implies system stress)
-                // We don't necessarily count refusal as a "failure" of the system, but the cause was failure.
-                return;
-            } else {
-                console.log('[Interlock Shadow Mode] Would refuse request');
-            }
-        } else {
-            // Healthy / Recovering
-            if (activeIncident) {
-                if (!recoveryWindowStart) recoveryWindowStart = Date.now();
-
-                if (Date.now() - recoveryWindowStart > RECOVERY_HYSTERESIS_MS) {
-                    // Confirm Recovery
-                    const duration = (Date.now() - activeIncident.start) / 1000;
-                    const recoveryTimeMs = Date.now() - activeIncident.start;
-
-                    sink.logEvent({
-                        incidentId: `${String(incidentId).padStart(3, '0')}-A`, // Event A (Resolution)
-                        trigger: 'Recovery',
-                        action: 'Traffic Refusal / Degraded Mode',
-                        details: 'System refused traffic to prevent collapse',
-                        recoveryTime: duration,
-                        confidence: monitor.getConfidence(),
-                        failureClass
-                    });
-
-                    // Emit SDE intervention event for recovery
-                    if (enableSdeTelemetry) {
-                        emitInterventionEvent({
-                            domain,
-                            trigger: {
-                                interlockTrigger: 'recovery',
-                                thresholdMs: latencyThresholdMs,
-                                observedMs: latencyProbe.getStats().meanMs || 0,
-                                confidence: monitor.getConfidence()
-                            },
-                            action: {
-                                interlockAction: 'circuit_close',
-                                priorState: 'open',
-                                newState: 'closed'
-                            },
-                            recovery: {
-                                timeMs: recoveryTimeMs,
-                                probeAttempts: 1,
-                                finalState: 'closed'
-                            }
-                        });
-                    }
-
-                    console.log(`[Interlock] ✅ Incident #${incidentId} Resolved`);
-                    activeIncident = null;
-                    recoveryWindowStart = null;
-                }
+            if (decision.mode === 'ENFORCE') return res.status(decision.status_code).json({ refused: true, incident_id: incidentId, reason: decision.reason, retry_after_ms: 5000, decision });
+        } else if (activeIncident) {
+            if (!recoveryWindowStart) recoveryWindowStart = Date.now();
+            if (Date.now() - recoveryWindowStart > RECOVERY_HYSTERESIS_MS) {
+                const duration = (Date.now() - activeIncident.start) / 1000;
+                const recoveryTimeMs = Date.now() - activeIncident.start;
+                sink.logEvent({ incidentId: `${String(incidentId).padStart(3, '0')}-A`, trigger: 'Recovery', action: 'Traffic Refusal / Degraded Mode', details: 'System refused traffic to prevent collapse', recoveryTime: duration, confidence: monitor.getConfidence(), failureClass });
+                if (enableSdeTelemetry) emitInterventionEvent({ domain, trigger: { interlockTrigger: 'recovery', thresholdMs: latencyThresholdMs, observedMs: latencyProbe.getStats().meanMs || 0, confidence: monitor.getConfidence() }, action: { interlockAction: 'circuit_close', priorState: 'open', newState: 'closed' }, recovery: { timeMs: recoveryTimeMs, probeAttempts: 1, finalState: 'closed' } });
+                activeIncident = null; recoveryWindowStart = null;
             }
         }
 
-        // Chaos Injection Check (Testing Mode)
-        // This runs ONLY if Refusal check passed (i.e. Confidence is OK or Dry Run)
-        if (failureInjector.shouldInjectFailure()) {
-            return res.status(500).json({ error: 'Interlock Simulated Failure (Chaos)' });
-        }
-
-
+        if (failureInjector.shouldInjectFailure()) return res.status(500).json({ error: 'Interlock Simulated Failure (Chaos)' });
         next();
     };
 }
 
-/**
- * Stop SDE telemetry (cleanup for tests/shutdown)
- */
 export function stopSdeTelemetry(): void {
     if (healthWindowStopper) {
         healthWindowStopper();
@@ -297,4 +158,3 @@ export function stopSdeTelemetry(): void {
     }
     metricsCollector = null;
 }
-

--- a/python/interlock_fastapi/client.py
+++ b/python/interlock_fastapi/client.py
@@ -1,61 +1,76 @@
 import httpx
-import time
 import logging
+from typing import Dict, TypedDict, Literal
+from datetime import datetime
 
 logger = logging.getLogger("interlock")
 
+Mode = Literal["ENFORCE", "SHADOW_ONLY"]
+Action = Literal["ALLOW", "DEGRADE", "REFUSE", "BLOCK"]
+
+class EnforcementDecision(TypedDict, total=False):
+    mode: Mode
+    action: Action
+    reason: str
+    law_hash: str
+    request_id: str
+    stream_id: str
+    action_taken: str
+    status_code: int
+    timestamp: str
+
+
 class InterlockClient:
-    def __init__(self, base_url: str, timeout_ms: int = 100):
+    def __init__(self, base_url: str, timeout_ms: int = 100, fail_closed: bool = True, dev_fail_open_override: bool = False):
         self.base_url = base_url.rstrip('/')
         self.timeout = timeout_ms / 1000.0
-        # Fail-open by default for dev safety, but can be configured
-        self.fail_closed = False 
+        self.fail_closed = fail_closed
+        self.dev_fail_open_override = dev_fail_open_override
 
-    async def get_decision(self, context: dict) -> dict:
-        """
-        Queries the Interlock Brain for a decision.
-        Returns spec: { allowed: bool, refusal: dict, context: dict }
-        """
+    async def get_decision(self, context: dict) -> Dict:
+        request_id = context.get("request_id", f"req-{int(datetime.utcnow().timestamp()*1000)}")
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
-                response = await client.post(
-                    f"{self.base_url}/interlock/decision",
-                    json=context
-                )
-                
-                if response.status_code == 200:
-                    return response.json()
-                else:
-                    logger.error(f"Interlock Error: HTTP {response.status_code}")
-                    return self._fallback_decision("http_error")
+                response = await client.post(f"{self.base_url}/interlock/decision", json=context)
+                if response.status_code != 200:
+                    return self._fallback_decision("http_error", request_id)
 
+                data = response.json()
+                if not self._valid_brain_response(data):
+                    return self._fallback_decision("malformed_decision", request_id)
+                return data
         except httpx.TimeoutException:
-            logger.warning("Interlock Timeout: Core did not respond in time")
-            return self._fallback_decision("timeout")
+            return self._fallback_decision("timeout", request_id)
         except httpx.RequestError as e:
             logger.error(f"Interlock Connection Error: {str(e)}")
-            return self._fallback_decision("connection_error")
+            return self._fallback_decision("connection_error", request_id)
 
-    def _fallback_decision(self, reason: str) -> dict:
-        """
-        Determines behavior when Brain is unreachable.
-        """
-        if self.fail_closed:
+    def _valid_brain_response(self, data: dict) -> bool:
+        return isinstance(data, dict) and 'decision' in data and isinstance(data['decision'], dict) and 'action' in data['decision']
+
+    def _fallback_decision(self, reason: str, request_id: str) -> Dict:
+        if self.fail_closed and not self.dev_fail_open_override:
             return {
-                "allowed": False,
-                "refusal": {
+                "decision": {
+                    "mode": "ENFORCE",
+                    "action": "BLOCK",
                     "reason": f"Interlock System Failure ({reason}) - Fail Closed",
-                    "retry_after_ms": 10000,
-                    "incident_id": "failsafe-000",
-                    "confidence": 0.0
+                    "law_hash": "control-plane-fallback",
+                    "request_id": request_id,
+                    "action_taken": "BLOCKED_FAIL_CLOSED",
+                    "status_code": 503,
+                    "timestamp": datetime.utcnow().isoformat()
                 }
             }
-        else:
-            # Fail Open (Shadow Mode log would happen here ideally)
-            return {
-                "allowed": True,
-                "metadata": {
-                    "confidence": 1.0, # Assume 1.0 if we can't check
-                    "failsafe": True
-                }
+        return {
+            "decision": {
+                "mode": "SHADOW_ONLY",
+                "action": "DEGRADE",
+                "reason": f"Interlock System Failure ({reason}) - Dev Fail Open Override",
+                "law_hash": "control-plane-fallback",
+                "request_id": request_id,
+                "action_taken": "DEV_FAIL_OPEN_OVERRIDE",
+                "status_code": 200,
+                "timestamp": datetime.utcnow().isoformat()
             }
+        }

--- a/python/interlock_fastapi/middleware.py
+++ b/python/interlock_fastapi/middleware.py
@@ -1,77 +1,53 @@
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 from starlette.requests import Request
-import time
-import asyncio
+from datetime import datetime
 from .client import InterlockClient
 from .sink import IncidentSink
 
 class InterlockMiddleware(BaseHTTPMiddleware):
-    def __init__(
-        self, 
-        app, 
-        interlock_url: str = "http://localhost:3000",
-        log_file: str = "docs/LIVE_INCIDENTS.md",
-        dry_run: bool = False
-    ):
+    def __init__(self, app, interlock_url: str = "http://localhost:3000", log_file: str = "docs/LIVE_INCIDENTS.md", dry_run: bool = False, fail_closed: bool = True, dev_fail_open_override: bool = False):
         super().__init__(app)
-        self.client = InterlockClient(interlock_url)
+        self.client = InterlockClient(interlock_url, fail_closed=fail_closed, dev_fail_open_override=dev_fail_open_override)
         self.sink = IncidentSink(log_file)
         self.dry_run = dry_run
-        self.incident_buffer = {} # Simple state for debouncing LOGGING (not decision)
+        self.enforcement_count = 0
 
     async def dispatch(self, request: Request, call_next):
-        start_time = time.time()
-        
-        # 1. Ask Brain
-        decision = await self.client.get_decision({
-            "path": request.url.path,
-            "method": request.method
+        request_id = request.headers.get("x-request-id", f"req-{int(datetime.utcnow().timestamp()*1000)}")
+
+        if request.url.path.endswith('/stream'):
+            return JSONResponse(status_code=501, content={
+                "error": "Streaming enforcement unsupported without protocol adapter",
+                "request_id": request_id,
+                "todo": ["SSE/NDJSON fatal event then close", "WebSocket close code 1008", "raw/unknown transport abort"]
+            })
+
+        payload = {"path": request.url.path, "method": request.method, "request_id": request_id}
+        result = await self.client.get_decision(payload)
+        decision = result.get("decision", {})
+
+        if self.dry_run:
+            decision["mode"] = "SHADOW_ONLY"
+            if decision.get("action") in ["REFUSE", "BLOCK"]:
+                decision["action_taken"] = f"WOULD_{decision['action']}"
+
+        print("[Interlock Enforcement]", {
+            "law_hash": decision.get("law_hash"), "request_id": decision.get("request_id", request_id), "mode": decision.get("mode"),
+            "action": decision.get("action"), "action_taken": decision.get("action_taken"), "reason": decision.get("reason"),
+            "timestamp": decision.get("timestamp", datetime.utcnow().isoformat())
         })
 
-        # 2. Enforce Decision
-        if not decision.get("allowed", True):
-            refusal = decision["refusal"]
-            
-            # Log Incident (Safe Wrap)
-            # We must never crash the response generation just because logging failed.
+        action = decision.get("action", "ALLOW")
+        if action in ["REFUSE", "BLOCK", "DEGRADE"]:
+            if decision.get("mode") != "SHADOW_ONLY":
+                self.enforcement_count += 1
             try:
-                self.sink.log_event({
-                    "incident_id": refusal.get("incident_id"),
-                    "trigger": "Remote Refusal",
-                    "action": "Traffic Refusal",
-                    "failure_class": "Remote Decision",
-                    "confidence": refusal.get("confidence")
-                })
-            except Exception as e:
-                # If logging fails, we still return the 503.
-                # In production, we might emit to stderr or a fallback.
-                print(f"[Interlock Middleware] Logging failed: {e}")
+                self.sink.log_event({"incident_id": decision.get("request_id", request_id), "trigger": "Remote Decision", "action": action, "failure_class": "Runtime Enforcement", "confidence": 0.0})
+            except Exception:
+                pass
+            if decision.get("mode") != "SHADOW_ONLY":
+                return JSONResponse(status_code=decision.get("status_code", 503), content={"refused": True, "decision": decision})
 
-            if not self.dry_run:
-                return JSONResponse(
-                    status_code=503,
-                    content={
-                        "refused": True,
-                        "reason": refusal.get("reason"),
-                        "incident_id": refusal.get("incident_id"),
-                        "retry_after_ms": refusal.get("retry_after_ms")
-                    }
-                )
-            else:
-                print(f"[Interlock Shadow] Would Refuse: {refusal}")
-
-        # 3. Proceed
         response = await call_next(request)
-        
-        # Metric hook could go here (send latency back to Brain?)
-        # For Phase 3B "Remote Client", Brain monitors itself via its own adapter 
-        # acting as the Proxy/Sidecar or receiving distinct signals.
-        # But wait, if Brain is separate process, it doesn't see THIS request's latency 
-        # unless we send it back.
-        # The prompt says: "Do not re-implement hazard logic". 
-        # It implies the Brain uses its OWN internal state (from the Reference App load)
-        # OR we send metrics. 
-        # For "Phase 3B", we rely on the Brain's internal state (which we are mocking via Force/Lag).
-        
         return response

--- a/tests/runtime/interlock_boundary.test.ts
+++ b/tests/runtime/interlock_boundary.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { interlockExpress } from '../../packages/interlock-express/src/index';
+
+describe('interlock boundary', () => {
+  it('express refusal prevents downstream', () => {
+    const mw = interlockExpress({ dry_run: false, quality_floor: 1.1 });
+    const req: any = { path: '/work', query: {}, headers: {} };
+    const status = vi.fn().mockReturnThis();
+    const json = vi.fn().mockReturnThis();
+    const res: any = { on: vi.fn(), statusCode: 200, status, json };
+    const next = vi.fn();
+    mw(req, res, next);
+    expect(status).toHaveBeenCalledWith(503);
+    expect(next).not.toHaveBeenCalled();
+    const body = json.mock.calls[0][0];
+    expect(body.decision.law_hash).toBeTruthy();
+  });
+
+  it('streaming route unsupported', () => {
+    const mw = interlockExpress({ dry_run: false });
+    const req: any = { path: '/x/stream', query: {}, headers: {} };
+    const status = vi.fn().mockReturnThis();
+    const json = vi.fn().mockReturnThis();
+    const res: any = { on: vi.fn(), status, json };
+    mw(req, res, vi.fn());
+    expect(status).toHaveBeenCalledWith(501);
+  });
+});

--- a/tests/runtime/test_fastapi_enforcement.py
+++ b/tests/runtime/test_fastapi_enforcement.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import AsyncMock
+from starlette.requests import Request
+from starlette.responses import Response
+from python.interlock_fastapi.client import InterlockClient
+from python.interlock_fastapi.middleware import InterlockMiddleware
+
+class TestFastAPIBoundary(unittest.IsolatedAsyncioTestCase):
+    async def test_timeout_fails_closed_default(self):
+        c = InterlockClient('http://x')
+        d = c._fallback_decision('timeout', 'r1')['decision']
+        self.assertEqual(d['action'], 'BLOCK')
+        self.assertEqual(d['mode'], 'ENFORCE')
+
+    async def test_non200_and_malformed_fail_closed(self):
+        c = InterlockClient('http://x')
+        d = c._fallback_decision('http_error', 'r2')['decision']
+        self.assertEqual(d['status_code'], 503)
+        self.assertFalse(c._valid_brain_response({'allowed': True}))
+
+    async def test_dev_fail_open_override_stamped(self):
+        c = InterlockClient('http://x', fail_closed=True, dev_fail_open_override=True)
+        d = c._fallback_decision('timeout', 'r3')['decision']
+        self.assertEqual(d['mode'], 'SHADOW_ONLY')
+        self.assertEqual(d['action_taken'], 'DEV_FAIL_OPEN_OVERRIDE')
+
+    async def test_middleware_refusal_prevents_call_next(self):
+        m = InterlockMiddleware(app=lambda scope, receive, send: None)
+        m.client.get_decision = AsyncMock(return_value={"decision": {"mode":"ENFORCE","action":"REFUSE","reason":"r","law_hash":"h","request_id":"id","action_taken":"REFUSED","status_code":503,"timestamp":"t"}})
+        scope = {"type": "http", "method": "GET", "path": "/work", "headers": []}
+        req = Request(scope)
+        call_next = AsyncMock(return_value=Response('ok'))
+        resp = await m.dispatch(req, call_next)
+        self.assertEqual(resp.status_code, 503)
+        call_next.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce a single, structured enforcement decision schema between the Brain, Express middleware, and FastAPI client to standardize enforcement signals and metadata.
- Provide safer defaults for operator workflows by adding configurable fail-closed behavior and a dev fail-open override, plus clearer dry-run/shadow handling.
- Add explicit handling for streaming routes and emit lightweight enforcement telemetry to make enforcement actions observable and debuggable.

### Description
- Changed the Brain HTTP contract to return a `decision` object (fields: `mode`, `action`, `reason`, `law_hash`, `request_id`, `action_taken`, `status_code`, `timestamp`) and ensured `request_id` is propagated when present (`apps/live-monitor/server.ts`).
- Refactored the Express middleware (`packages/interlock-express/src/index.ts`) to define `EnforcementDecision` types, emit telemetry via `emitEnforcementTelemetry`, load law parameters robustly, handle `/stream` routes with a 501 guard, record enforcement decisions (with dry-run/shadow behavior), and simplify incident logging and recovery hysteresis.
- Updated the Python client (`python/interlock_fastapi/client.py`) to validate the new `decision` response shape, stamp and propagate `request_id`, support `fail_closed` and `dev_fail_open_override` flags, and return structured fallback `decision` objects on timeout/connection/malformed responses.
- Updated the Python middleware (`python/interlock_fastapi/middleware.py`) to create/propagate `request_id`, guard streaming endpoints with a 501, apply dry-run mode by forcing `mode = SHADOW_ONLY`, and enforce/block based on the new `decision` schema.
- Added automated tests for both runtimes: a Vitest runtime boundary test for the Express middleware (`tests/runtime/interlock_boundary.test.ts`) and Python unittest cases for client fallback behavior and middleware enforcement (`tests/runtime/test_fastapi_enforcement.py`).

### Testing
- Ran the TypeScript runtime test `tests/runtime/interlock_boundary.test.ts` with Vitest and the tests passed.
- Ran the Python unittest file `tests/runtime/test_fastapi_enforcement.py` and all assertions passed.
- Local basic smoke validation performed by exercising the middleware decision paths (refuse/allow/stream) in test harnesses and logging observed decisions to ensure schema compliance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f204670b1c83248e582a08603dfa90)