### PR TITLE
fix: keep demo control-plane reset reachable under refusal

### DIFF
--- a/apps/examples/express-demo/server.ts
+++ b/apps/examples/express-demo/server.ts
@@ -35,6 +35,7 @@ app.use(rateLimiter);
 
 // Enable Interlock - E2E testing with LLM-appropriate thresholds
 app.use(interlockExpress({
+    control_plane_paths: ['/admin/inject-failure'],
     quality_floor: 0.3,        // Low floor for LLM testing (0.3)
     dry_run: false,            // REAL Ollama calls
     latency_threshold_ms: 10000,  // 10s threshold for LLM workloads
@@ -93,6 +94,7 @@ app.post('/admin/inject-failure', (req, res) => {
             res.json({ status: 'injected', mode: 'FORCE_ERROR' });
         } else if (mode === 'RESET') {
             req.interlock.failureInjector.disableInjection();
+            req.interlock.failureInjector.clear();
             req.interlock.monitor.reset();
             res.json({ status: 'reset' });
         } else {

--- a/packages/interlock-express/src/index.ts
+++ b/packages/interlock-express/src/index.ts
@@ -33,6 +33,11 @@ export interface InterlockOptions {
     domain?: Domain;
     enable_sde_telemetry?: boolean;
     workload?: { model_id: string; provider: string };
+    /**
+     * Explicit local/demo control-plane paths that must remain reachable even
+     * when data-plane traffic is being refused. Defaults to no bypass.
+     */
+    control_plane_paths?: string[];
 }
 
 declare global { namespace Express { interface Request { interlock?: { monitor: ConfidenceMonitor; failureInjector: FailureInjector; } } } }
@@ -61,6 +66,7 @@ export function interlockExpress(options: InterlockOptions = {}) {
     const failureInjector = new FailureInjector();
     const monitor = new ConfidenceMonitor(latencyProbe, failureInjector, qualityFloor, latencyThresholdMs);
     const sink: IncidentSink = new FileIncidentSink(logFile);
+    const controlPlanePaths = new Set(options.control_plane_paths ?? []);
 
     if (enableSdeTelemetry) {
         initKernelStamp(options.workload ?? { model_id: 'gemma3:1b', provider: domain });
@@ -98,6 +104,11 @@ export function interlockExpress(options: InterlockOptions = {}) {
                 error: 'Streaming enforcement unsupported without protocol adapter',
                 enforcement_todo: ['SSE/NDJSON fatal event then close', 'WebSocket close code 1008', 'raw/unknown transport abort']
             });
+        }
+
+        if (controlPlanePaths.has(req.path)) {
+            req.interlock = { monitor, failureInjector };
+            return next();
         }
 
         const startTime = Date.now();

--- a/test/interlockExpress.control-plane.test.ts
+++ b/test/interlockExpress.control-plane.test.ts
@@ -1,0 +1,93 @@
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Server } from 'node:http';
+import { interlockExpress, stopSdeTelemetry } from '../packages/interlock-express/src/index.ts';
+
+describe('interlockExpress control plane paths', () => {
+    let server: Server | null = null;
+
+    afterEach(async () => {
+        stopSdeTelemetry();
+        if (server) {
+            await new Promise<void>((resolve, reject) => {
+                server?.close(error => error ? reject(error) : resolve());
+            });
+            server = null;
+        }
+    });
+
+    it('allows demo failure reset while data-plane traffic is refused', async () => {
+        const app = express();
+        const tmp = mkdtempSync(join(tmpdir(), 'interlock-control-plane-'));
+
+        app.use(interlockExpress({
+            control_plane_paths: ['/admin/inject-failure'],
+            enable_sde_telemetry: false,
+            incident_file: join(tmp, 'LIVE_INCIDENTS.md'),
+            quality_floor: 0.3
+        }));
+        app.use(express.json());
+
+        app.post('/admin/inject-failure', (req, res) => {
+            const { mode } = req.body;
+            if (!req.interlock) return res.status(500).json({ error: 'missing interlock control plane' });
+
+            if (mode === 'FORCE_ERROR') {
+                req.interlock.failureInjector.enableInjection(1.0);
+                return res.json({ status: 'injected', mode: 'FORCE_ERROR' });
+            }
+            if (mode === 'RESET') {
+                req.interlock.failureInjector.disableInjection();
+                req.interlock.failureInjector.clear();
+                req.interlock.monitor.reset();
+                return res.json({ status: 'reset' });
+            }
+            return res.status(400).json({ error: 'Unknown mode' });
+        });
+
+        app.post('/work', (_req, res) => {
+            res.json({ status: 'done' });
+        });
+
+        server = app.listen(0);
+        await new Promise<void>(resolve => server?.once('listening', resolve));
+        const address = server.address();
+        if (!address || typeof address === 'string') throw new Error('expected tcp listener');
+        const baseUrl = `http://127.0.0.1:${address.port}`;
+
+        const force = await postJson(`${baseUrl}/admin/inject-failure`, { mode: 'FORCE_ERROR' });
+        expect(force.status).toBe(200);
+
+        let refusedResponse: Response | null = null;
+        for (let i = 0; i < 15; i++) {
+            const response = await postJson(`${baseUrl}/work`, {});
+            if (response.status === 503) {
+                refusedResponse = response;
+                break;
+            }
+        }
+
+        expect(refusedResponse?.status).toBe(503);
+        const refusedBody = await refusedResponse?.json();
+        expect(refusedBody.refused).toBe(true);
+
+        const reset = await postJson(`${baseUrl}/admin/inject-failure`, { mode: 'RESET' });
+        expect(reset.status).toBe(200);
+        await expect(reset.json()).resolves.toEqual({ status: 'reset' });
+
+        const recovered = await postJson(`${baseUrl}/work`, {});
+        expect(recovered.status).toBe(200);
+        await expect(recovered.json()).resolves.toEqual({ status: 'done' });
+    });
+});
+
+function postJson(url: string, body: unknown): Promise<Response> {
+    return fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+}

--- a/test/interlockExpress.control-plane.test.ts
+++ b/test/interlockExpress.control-plane.test.ts
@@ -6,10 +6,39 @@ import { join } from 'node:path';
 import type { Server } from 'node:http';
 import { interlockExpress, stopSdeTelemetry } from '../packages/interlock-express/src/index.ts';
 
+const rateLimitStore = new Map<string, { count: number; resetTime: number }>();
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 100;
+
+function rateLimiter(
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+): void {
+    const ip = req.ip || req.socket.remoteAddress || 'unknown';
+    const now = Date.now();
+    const record = rateLimitStore.get(ip);
+
+    if (!record || now > record.resetTime) {
+        rateLimitStore.set(ip, { count: 1, resetTime: now + RATE_LIMIT_WINDOW_MS });
+        next();
+        return;
+    }
+
+    if (record.count >= RATE_LIMIT_MAX) {
+        res.status(429).json({ error: 'Too many requests' });
+        return;
+    }
+
+    record.count++;
+    next();
+}
+
 describe('interlockExpress control plane paths', () => {
     let server: Server | null = null;
 
     afterEach(async () => {
+        rateLimitStore.clear();
         stopSdeTelemetry();
         if (server) {
             await new Promise<void>((resolve, reject) => {
@@ -23,6 +52,7 @@ describe('interlockExpress control plane paths', () => {
         const app = express();
         const tmp = mkdtempSync(join(tmpdir(), 'interlock-control-plane-'));
 
+        app.use(rateLimiter);
         app.use(interlockExpress({
             control_plane_paths: ['/admin/inject-failure'],
             enable_sde_telemetry: false,


### PR DESCRIPTION
## Summary

- Adds opt-in `control_plane_paths` to `interlockExpress`; default remains no bypass.
- Express demo opts in only for `/admin/inject-failure`.
- Control-plane paths receive `req.interlock` but skip normal refusal/failure injection.
- `RESET` clears failure injection and recorded failure signals, then resets monitor.
- `/work` remains governed under failure/refusal.
- Does not modify SDE.
- Issue 2 / trigger-aware SDE proposal search is intentionally not included.

## Manual Runtime Proof

`FORCE_ERROR` -> `/work` 500/503 -> `RESET` 200 -> `/work` 200 recovered.

## Validation

- TypeScript lint passed: `node.exe .\node_modules\typescript\bin\tsc --noEmit -p tsconfig.ci.json`
- Focused Vitest passed: `node.exe .\node_modules\vitest\vitest.mjs run test\interlockExpress.control-plane.test.ts`