### PR TITLE
fix: align runtime event stamps with loaded law hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@types/node": "^22.19.2",
         "@vitejs/plugin-react": "^5.0.0",
+        "express-rate-limit": "^8.5.1",
         "tsx": "^4.19.0",
         "typescript": "~5.8.2",
         "vite": "^6.2.0",
@@ -2312,6 +2313,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2707,6 +2727,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/node": "^22.19.2",
     "@vitejs/plugin-react": "^5.0.0",
+    "express-rate-limit": "^8.5.1",
     "tsx": "^4.19.0",
     "typescript": "~5.8.2",
     "vite": "^6.2.0",

--- a/packages/interlock-express/src/index.ts
+++ b/packages/interlock-express/src/index.ts
@@ -8,6 +8,8 @@ import { emitInterventionEvent } from './intervention-emitter';
 import { loadLaw } from '../../../services/law-loader';
 import { Domain } from '../../../services/events.types';
 import { initKernelStamp } from '../../../services/kernel/eventStamp';
+import type { RuntimeLawProvenance } from '../../../services/kernel/eventStamp';
+import { resetJsonlSink } from './jsonl-sink';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 
@@ -69,7 +71,10 @@ export function interlockExpress(options: InterlockOptions = {}) {
     const controlPlanePaths = new Set(options.control_plane_paths ?? []);
 
     if (enableSdeTelemetry) {
-        initKernelStamp(options.workload ?? { model_id: 'gemma3:1b', provider: domain });
+        initKernelStamp(
+            options.workload ?? { model_id: 'gemma3:1b', provider: domain },
+            buildRuntimeLawProvenance(domain, lawResult)
+        );
         const emitter = startHealthWindowEmitter({ domain, thresholds: { latency_threshold_ms: latencyThresholdMs, error_threshold_pct: errorThresholdPct } });
         metricsCollector = emitter.collector;
         healthWindowStopper = emitter.stop;
@@ -165,10 +170,31 @@ export function interlockExpress(options: InterlockOptions = {}) {
     };
 }
 
+function buildRuntimeLawProvenance(domain: Domain, lawResult: ReturnType<typeof loadLaw>): RuntimeLawProvenance {
+    const law = lawResult.law as any;
+    const packetId =
+        law?.evidence?.packet_id ||
+        law?.source?.packet_id ||
+        law?.source?.proposal_id ||
+        law?.proposal_id;
+    const qualityLevel =
+        law?.evidence?.quality_level ||
+        law?.source?.quality_level ||
+        law?.quality_level;
+
+    return {
+        domain,
+        law_hash: lawResult.success ? lawResult.lawHash : 'default',
+        packet_id: packetId,
+        quality_level: qualityLevel
+    };
+}
+
 export function stopSdeTelemetry(): void {
     if (healthWindowStopper) {
         healthWindowStopper();
         healthWindowStopper = null;
     }
     metricsCollector = null;
+    resetJsonlSink();
 }

--- a/packages/interlock-express/src/jsonl-sink.ts
+++ b/packages/interlock-express/src/jsonl-sink.ts
@@ -59,3 +59,7 @@ export function getJsonlSink(): JsonlEventSink {
     }
     return singletonSink;
 }
+
+export function resetJsonlSink(): void {
+    singletonSink = null;
+}

--- a/services/kernel/eventStamp.ts
+++ b/services/kernel/eventStamp.ts
@@ -34,10 +34,18 @@ export interface KernelStamp {
     invalid?: boolean;
 }
 
+export interface RuntimeLawProvenance {
+    domain: string;
+    law_hash?: string;
+    packet_id?: string;
+    quality_level?: string;
+}
+
 // ============= Cached Kernel State =============
 
 let cachedKernel: KernelLoadResult | null = null;
 let cachedStamp: KernelStamp | null = null;
+let warnedLawHashConflict = false;
 
 /**
  * Initialize kernel and cache stamp for event emission.
@@ -45,11 +53,33 @@ let cachedStamp: KernelStamp | null = null;
  * 
  * @param workload Optional workload identity to stamp (e.g. { model_id: 'gemma3:12b' })
  */
-export function initKernelStamp(workload?: { model_id: string; provider: string }): KernelStamp {
+export function initKernelStamp(
+    workload?: { model_id: string; provider: string },
+    runtimeLaw?: RuntimeLawProvenance
+): KernelStamp {
     cachedKernel = loadKernel();
     // Use the newly exported computePhysicsHash
 
     const baseStamp = getKernelProvenance(cachedKernel);
+    const runtimeLawHash = runtimeLaw?.law_hash;
+    const runtimePacketId = runtimeLaw?.packet_id || (
+        runtimeLawHash ? `runtime-law-${runtimeLawHash}` : undefined
+    );
+
+    if (
+        runtimeLawHash &&
+        baseStamp.law_hash &&
+        baseStamp.law_hash !== 'unknown' &&
+        baseStamp.law_hash !== 'default' &&
+        baseStamp.law_hash !== runtimeLawHash &&
+        !warnedLawHashConflict
+    ) {
+        console.warn(
+            `[Interlock] Runtime law hash ${runtimeLawHash} differs from kernel law_hash ` +
+            `${baseStamp.law_hash}; event stamps will use runtime law hash.`
+        );
+        warnedLawHashConflict = true;
+    }
 
     const physicsHash = cachedKernel.success ? computePhysicsHash(cachedKernel.physics) : 'none';
 
@@ -58,6 +88,10 @@ export function initKernelStamp(workload?: { model_id: string; provider: string 
 
     cachedStamp = {
         ...baseStamp,
+        domain: runtimeLaw?.domain ?? baseStamp.domain,
+        law_hash: runtimeLawHash || safeStampValue(baseStamp.law_hash, 'default'),
+        packet_id: runtimePacketId || safeStampValue(baseStamp.packet_id, 'none'),
+        quality_level: runtimeLaw?.quality_level || safeStampValue(baseStamp.quality_level, 'L0-Observed'),
         physics_hash: physicsHash,
         workload: workload,
         hardware_fingerprint: hardwareStamp.hardware_fingerprint,
@@ -65,6 +99,11 @@ export function initKernelStamp(workload?: { model_id: string; provider: string 
     };
 
     return cachedStamp;
+}
+
+function safeStampValue(value: string | undefined, fallback: string): string {
+    if (!value || value === 'unknown') return fallback;
+    return value;
 }
 
 /**

--- a/test/runtimeLawStamp.test.ts
+++ b/test/runtimeLawStamp.test.ts
@@ -10,6 +10,34 @@ import { buildHealthWindowEvent, createMetricsCollector, recordRequest } from '.
 import { initKernelStamp } from '../services/kernel/eventStamp.ts';
 import { loadLaw } from '../services/law-loader.ts';
 
+const rateLimitStore = new Map<string, { count: number; resetTime: number }>();
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 100;
+
+function rateLimiter(
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+): void {
+    const ip = req.ip || req.socket.remoteAddress || 'unknown';
+    const now = Date.now();
+    const record = rateLimitStore.get(ip);
+
+    if (!record || now > record.resetTime) {
+        rateLimitStore.set(ip, { count: 1, resetTime: now + RATE_LIMIT_WINDOW_MS });
+        next();
+        return;
+    }
+
+    if (record.count >= RATE_LIMIT_MAX) {
+        res.status(429).json({ error: 'Too many requests' });
+        return;
+    }
+
+    record.count++;
+    next();
+}
+
 describe('runtime law event stamp alignment', () => {
     let server: Server | null = null;
     const originalLawPath = process.env.INTERLOCK_LAW_PATH;
@@ -18,6 +46,7 @@ describe('runtime law event stamp alignment', () => {
     const originalKernelPath = process.env.COGNITIVE_KERNEL_PATH;
 
     afterEach(async () => {
+        rateLimitStore.clear();
         stopSdeTelemetry();
         if (server) {
             await new Promise<void>((resolve, reject) => {
@@ -50,6 +79,7 @@ describe('runtime law event stamp alignment', () => {
 
         const expectedLawHash = loadLaw('ollama').lawHash;
         const app = express();
+        app.use(rateLimiter);
         app.use(interlockExpress({ enable_sde_telemetry: true }));
         app.post('/work', (_req, res) => res.json({ status: 'done' }));
 

--- a/test/runtimeLawStamp.test.ts
+++ b/test/runtimeLawStamp.test.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import { afterEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -10,33 +11,12 @@ import { buildHealthWindowEvent, createMetricsCollector, recordRequest } from '.
 import { initKernelStamp } from '../services/kernel/eventStamp.ts';
 import { loadLaw } from '../services/law-loader.ts';
 
-const rateLimitStore = new Map<string, { count: number; resetTime: number }>();
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX = 100;
-
-function rateLimiter(
-    req: express.Request,
-    res: express.Response,
-    next: express.NextFunction
-): void {
-    const ip = req.ip || req.socket.remoteAddress || 'unknown';
-    const now = Date.now();
-    const record = rateLimitStore.get(ip);
-
-    if (!record || now > record.resetTime) {
-        rateLimitStore.set(ip, { count: 1, resetTime: now + RATE_LIMIT_WINDOW_MS });
-        next();
-        return;
-    }
-
-    if (record.count >= RATE_LIMIT_MAX) {
-        res.status(429).json({ error: 'Too many requests' });
-        return;
-    }
-
-    record.count++;
-    next();
-}
+const rateLimiter = rateLimit({
+    windowMs: 60_000,
+    limit: 100,
+    standardHeaders: true,
+    legacyHeaders: false
+});
 
 describe('runtime law event stamp alignment', () => {
     let server: Server | null = null;
@@ -46,7 +26,6 @@ describe('runtime law event stamp alignment', () => {
     const originalKernelPath = process.env.COGNITIVE_KERNEL_PATH;
 
     afterEach(async () => {
-        rateLimitStore.clear();
         stopSdeTelemetry();
         if (server) {
             await new Promise<void>((resolve, reject) => {

--- a/test/runtimeLawStamp.test.ts
+++ b/test/runtimeLawStamp.test.ts
@@ -1,0 +1,177 @@
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Server } from 'node:http';
+import { interlockExpress, stopSdeTelemetry } from '../packages/interlock-express/src/index.ts';
+import { emitInterventionEvent } from '../packages/interlock-express/src/intervention-emitter.ts';
+import { buildHealthWindowEvent, createMetricsCollector, recordRequest } from '../packages/interlock-express/src/health-window.ts';
+import { initKernelStamp } from '../services/kernel/eventStamp.ts';
+import { loadLaw } from '../services/law-loader.ts';
+
+describe('runtime law event stamp alignment', () => {
+    let server: Server | null = null;
+    const originalLawPath = process.env.INTERLOCK_LAW_PATH;
+    const originalEventsPath = process.env.INTERLOCK_EVENTS_PATH;
+    const originalHealthWindowMs = process.env.INTERLOCK_HEALTH_WINDOW_MS;
+    const originalKernelPath = process.env.COGNITIVE_KERNEL_PATH;
+
+    afterEach(async () => {
+        stopSdeTelemetry();
+        if (server) {
+            await new Promise<void>((resolve, reject) => {
+                server?.close(error => error ? reject(error) : resolve());
+            });
+            server = null;
+        }
+
+        restoreEnv('INTERLOCK_LAW_PATH', originalLawPath);
+        restoreEnv('INTERLOCK_EVENTS_PATH', originalEventsPath);
+        restoreEnv('INTERLOCK_HEALTH_WINDOW_MS', originalHealthWindowMs);
+        restoreEnv('COGNITIVE_KERNEL_PATH', originalKernelPath);
+
+        for (const dir of tempDirsForCleanup) {
+            rmSync(dir, { recursive: true, force: true });
+        }
+        tempDirsForCleanup.length = 0;
+    });
+
+    it('stamps health_window events with the loaded runtime law hash', async () => {
+        const tmp = makeTempDir();
+        const lawPath = join(tmp, 'law.json');
+        const eventsPath = join(tmp, 'events.jsonl');
+        writeFileSync(lawPath, JSON.stringify(makeLaw({ latency_threshold_ms: 1900 }), null, 2));
+
+        process.env.INTERLOCK_LAW_PATH = lawPath;
+        process.env.INTERLOCK_EVENTS_PATH = eventsPath;
+        process.env.INTERLOCK_HEALTH_WINDOW_MS = '20';
+        process.env.COGNITIVE_KERNEL_PATH = join(tmp, 'missing-kernel.json');
+
+        const expectedLawHash = loadLaw('ollama').lawHash;
+        const app = express();
+        app.use(interlockExpress({ enable_sde_telemetry: true }));
+        app.post('/work', (_req, res) => res.json({ status: 'done' }));
+
+        server = app.listen(0);
+        await new Promise<void>(resolve => server?.once('listening', resolve));
+        const address = server.address();
+        if (!address || typeof address === 'string') throw new Error('expected tcp listener');
+
+        const response = await fetch(`http://127.0.0.1:${address.port}/work`, { method: 'POST' });
+        expect(response.status).toBe(200);
+
+        const event = await readFirstEvent(eventsPath);
+        expect(event.event_type).toBe('health_window');
+        expect(event.kernel.law_hash).toBe(expectedLawHash);
+        expect(event.kernel.domain).toBe('ollama');
+        expect(event.kernel.packet_id).toBe(`runtime-law-${expectedLawHash}`);
+        expect(event.kernel.quality_level).toBe('L0-Observed');
+        expect(event.thresholds.latency_threshold_ms).toBe(1900);
+    });
+
+    it('stamps intervention events with the active runtime law hash', () => {
+        const tmp = makeTempDir();
+        const lawPath = join(tmp, 'law.json');
+        const eventsPath = join(tmp, 'events.jsonl');
+        writeFileSync(lawPath, JSON.stringify(makeLaw({ confidence_floor: 0.8 }), null, 2));
+
+        process.env.INTERLOCK_LAW_PATH = lawPath;
+        process.env.INTERLOCK_EVENTS_PATH = eventsPath;
+        process.env.COGNITIVE_KERNEL_PATH = join(tmp, 'missing-kernel.json');
+
+        const lawResult = loadLaw('ollama');
+        initKernelStamp(
+            { model_id: 'gemma3:1b', provider: 'ollama' },
+            { domain: 'ollama', law_hash: lawResult.lawHash, packet_id: 'packet-runtime-test', quality_level: 'L2-StressBattery' }
+        );
+
+        emitInterventionEvent({
+            domain: 'ollama',
+            trigger: { interlockTrigger: 'confidence_floor_breach', thresholdMs: 1900, observedMs: 2500, confidence: 0.2 },
+            action: { interlockAction: 'refuse', priorState: 'closed', newState: 'open' },
+            recovery: { timeMs: 0, probeAttempts: 0, finalState: 'open' }
+        });
+
+        const event = readEvents(eventsPath)[0];
+        expect(event.event_type).toBe('intervention');
+        expect(event.kernel.law_hash).toBe(lawResult.lawHash);
+        expect(event.kernel.domain).toBe('ollama');
+        expect(event.kernel.packet_id).toBe('packet-runtime-test');
+        expect(event.kernel.quality_level).toBe('L2-StressBattery');
+    });
+
+    it('fallback stamping still emits a non-empty law hash', () => {
+        const tmp = makeTempDir();
+        process.env.COGNITIVE_KERNEL_PATH = join(tmp, 'missing-kernel.json');
+
+        initKernelStamp({ model_id: 'gemma3:1b', provider: 'ollama' });
+        const collector = createMetricsCollector();
+        recordRequest(collector, 42, false);
+
+        const event = buildHealthWindowEvent(collector, 'ollama', {
+            latency_threshold_ms: 500,
+            error_threshold_pct: 0.05
+        });
+
+        expect(event.kernel.law_hash).toEqual(expect.any(String));
+        expect(event.kernel.law_hash.length).toBeGreaterThan(0);
+    });
+});
+
+function makeTempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'interlock-runtime-law-stamp-'));
+    tempDirsForCleanup.push(dir);
+    return dir;
+}
+
+const tempDirsForCleanup: string[] = [];
+
+function makeLaw(parameters: Partial<Record<string, number>> = {}) {
+    return {
+        law_id: 'law-runtime-stamp-test',
+        schema_version: '1.0.0',
+        domain: 'ollama',
+        hardware_fingerprint: null,
+        parameters: {
+            latency_threshold_ms: 500,
+            error_threshold_pct: 0.05,
+            recovery_timeout_ms: 60000,
+            probe_interval_ms: 5000,
+            confidence_floor: 0.5,
+            decay_rate: 0.1,
+            ...parameters
+        },
+        source: {
+            type: 'manual',
+            proposal_id: null,
+            created_at: '2026-05-06T00:00:00.000Z'
+        }
+    };
+}
+
+async function readFirstEvent(eventsPath: string): Promise<any> {
+    for (let i = 0; i < 50; i++) {
+        const events = readEvents(eventsPath);
+        if (events.length > 0) return events[0];
+        await new Promise(resolve => setTimeout(resolve, 20));
+    }
+    throw new Error(`No events emitted to ${eventsPath}`);
+}
+
+function readEvents(eventsPath: string): any[] {
+    try {
+        return readFileSync(eventsPath, 'utf-8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map(line => JSON.parse(line));
+    } catch {
+        return [];
+    }
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+}


### PR DESCRIPTION
## Summary
- Passes runtime law provenance from `loadLaw()` into event stamp initialization.
- Health-window and intervention events now prefer the active loaded law hash over kernel-profile `law_hash` when Interlock successfully loaded a runtime law.
- Keeps kernel physics/profile loading intact and falls back to safe non-empty stamp values for default/missing paths.
- Resets the JSONL sink when SDE telemetry is stopped so same-process restarts honor a new `INTERLOCK_EVENTS_PATH`.
- Adds focused tests for health-window stamps, intervention stamps, and fallback non-empty `law_hash` stamping.

## Manual proof
Started the Express demo with the extracted LawPack `law.json` from the local runtime compatibility proof:
- Interlock applied `latency_threshold_ms -> 1900`.
- `/work` with `gemma3:1b` returned HTTP 200 `done`.
- Enforcement log used `law_hash=941efdba37865677`.
- Emitted telemetry used `kernel.law_hash=941efdba37865677`.
- Emitted telemetry used `thresholds.latency_threshold_ms=1900` and `workload.model_id=gemma3:1b`.
- SDE `validate-log` accepted the live file: VALID, 2/2 parsed, required/recommended stamp coverage 100%.

## Validation
Used bundled Node because `npm.cmd`/system `node.exe` were unavailable or blocked in this shell.

- TypeScript lint equivalent: passed
- `scripts/validation-tests.ts`: all 12 validation series passed
- `scripts/sde-integration-test.ts`: 9 passed, 0 failed
- `scripts/validate-jsonl-schema.ts`: 28 passed, 0 failed
- `scripts/validate-law-loader.ts`: 15 passed, 0 failed
- `vitest run test/runtimeLawStamp.test.ts test/interlockExpress.control-plane.test.ts`: 4 passed

## Safety
- Interlock only.
- Does not modify SDE.
- Does not change LawPack ZIPs.
- Does not promote, ship, or import anything.
- Does not weaken validation.