### PR TITLE
fix: reset threshold-refusal state cleanly

### DIFF
--- a/apps/examples/express-demo/server.ts
+++ b/apps/examples/express-demo/server.ts
@@ -93,9 +93,7 @@ app.post('/admin/inject-failure', (req, res) => {
             req.interlock.failureInjector.enableInjection(1.0);
             res.json({ status: 'injected', mode: 'FORCE_ERROR' });
         } else if (mode === 'RESET') {
-            req.interlock.failureInjector.disableInjection();
-            req.interlock.failureInjector.clear();
-            req.interlock.monitor.reset();
+            req.interlock.resetRuntimeState();
             res.json({ status: 'reset' });
         } else {
             res.status(400).json({ error: 'Unknown mode' });

--- a/packages/interlock-express/src/index.ts
+++ b/packages/interlock-express/src/index.ts
@@ -3,7 +3,7 @@ import { ConfidenceMonitor } from '../../../adapters/pinecone/confidence_monitor
 import { LatencyProbe } from '../../../adapters/pinecone/latency_probe';
 import { FailureInjector } from '../../../adapters/pinecone/failure_injector';
 import { FileIncidentSink, IncidentSink } from './sink';
-import { startHealthWindowEmitter, recordRequest, MetricsCollector } from './health-window';
+import { startHealthWindowEmitter, recordRequest, resetMetricsCollector, MetricsCollector } from './health-window';
 import { emitInterventionEvent } from './intervention-emitter';
 import { loadLaw } from '../../../services/law-loader';
 import { Domain } from '../../../services/events.types';
@@ -42,7 +42,17 @@ export interface InterlockOptions {
     control_plane_paths?: string[];
 }
 
-declare global { namespace Express { interface Request { interlock?: { monitor: ConfidenceMonitor; failureInjector: FailureInjector; } } } }
+declare global {
+    namespace Express {
+        interface Request {
+            interlock?: {
+                monitor: ConfidenceMonitor;
+                failureInjector: FailureInjector;
+                resetRuntimeState: () => void;
+            }
+        }
+    }
+}
 let incidentId = 0;
 let activeIncident: { start: number, events: any[] } | null = null;
 let recoveryWindowStart: number | null = null;
@@ -69,6 +79,15 @@ export function interlockExpress(options: InterlockOptions = {}) {
     const monitor = new ConfidenceMonitor(latencyProbe, failureInjector, qualityFloor, latencyThresholdMs);
     const sink: IncidentSink = new FileIncidentSink(logFile);
     const controlPlanePaths = new Set(options.control_plane_paths ?? []);
+    const resetRuntimeState = () => {
+        failureInjector.disableInjection();
+        failureInjector.clear();
+        latencyProbe.clear();
+        monitor.reset();
+        activeIncident = null;
+        recoveryWindowStart = null;
+        if (metricsCollector) resetMetricsCollector(metricsCollector);
+    };
 
     if (enableSdeTelemetry) {
         initKernelStamp(
@@ -112,7 +131,7 @@ export function interlockExpress(options: InterlockOptions = {}) {
         }
 
         if (controlPlanePaths.has(req.path)) {
-            req.interlock = { monitor, failureInjector };
+            req.interlock = { monitor, failureInjector, resetRuntimeState };
             return next();
         }
 
@@ -130,7 +149,7 @@ export function interlockExpress(options: InterlockOptions = {}) {
         });
 
         monitor.update();
-        req.interlock = { monitor, failureInjector };
+        req.interlock = { monitor, failureInjector, resetRuntimeState };
 
         const requestId = (req.headers['x-request-id'] as string) || `req-${Date.now()}`;
         const decision: EnforcementDecision = monitor.shouldRefuse() ? {

--- a/test/interlockExpress.control-plane.test.ts
+++ b/test/interlockExpress.control-plane.test.ts
@@ -1,10 +1,11 @@
 import express from 'express';
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Server } from 'node:http';
 import { interlockExpress, stopSdeTelemetry } from '../packages/interlock-express/src/index.ts';
+import { loadLaw } from '../services/law-loader.ts';
 
 const rateLimitStore = new Map<string, { count: number; resetTime: number }>();
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -36,6 +37,10 @@ function rateLimiter(
 
 describe('interlockExpress control plane paths', () => {
     let server: Server | null = null;
+    const originalLawPath = process.env.INTERLOCK_LAW_PATH;
+    const originalEventsPath = process.env.INTERLOCK_EVENTS_PATH;
+    const originalHealthWindowMs = process.env.INTERLOCK_HEALTH_WINDOW_MS;
+    const tempDirsForCleanup: string[] = [];
 
     afterEach(async () => {
         rateLimitStore.clear();
@@ -46,6 +51,15 @@ describe('interlockExpress control plane paths', () => {
             });
             server = null;
         }
+
+        restoreEnv('INTERLOCK_LAW_PATH', originalLawPath);
+        restoreEnv('INTERLOCK_EVENTS_PATH', originalEventsPath);
+        restoreEnv('INTERLOCK_HEALTH_WINDOW_MS', originalHealthWindowMs);
+
+        for (const dir of tempDirsForCleanup) {
+            rmSync(dir, { recursive: true, force: true });
+        }
+        tempDirsForCleanup.length = 0;
     });
 
     it('allows demo failure reset while data-plane traffic is refused', async () => {
@@ -70,9 +84,7 @@ describe('interlockExpress control plane paths', () => {
                 return res.json({ status: 'injected', mode: 'FORCE_ERROR' });
             }
             if (mode === 'RESET') {
-                req.interlock.failureInjector.disableInjection();
-                req.interlock.failureInjector.clear();
-                req.interlock.monitor.reset();
+                req.interlock.resetRuntimeState();
                 return res.json({ status: 'reset' });
             }
             return res.status(400).json({ error: 'Unknown mode' });
@@ -112,6 +124,73 @@ describe('interlockExpress control plane paths', () => {
         expect(recovered.status).toBe(200);
         await expect(recovered.json()).resolves.toEqual({ status: 'done' });
     });
+
+    it('recovers after reset from threshold-induced refusal', async () => {
+        const app = express();
+        const tmp = mkdtempSync(join(tmpdir(), 'interlock-threshold-reset-'));
+        tempDirsForCleanup.push(tmp);
+        const lawPath = join(tmp, 'law.json');
+        const eventsPath = join(tmp, 'events.jsonl');
+        writeFileSync(lawPath, JSON.stringify(makeLaw({ latency_threshold_ms: 20, confidence_floor: 0.5 }), null, 2));
+
+        process.env.INTERLOCK_LAW_PATH = lawPath;
+        process.env.INTERLOCK_EVENTS_PATH = eventsPath;
+        process.env.INTERLOCK_HEALTH_WINDOW_MS = '20';
+        const expectedLawHash = loadLaw('ollama').lawHash;
+
+        app.use(rateLimiter);
+        app.use(interlockExpress({
+            control_plane_paths: ['/admin/inject-failure'],
+            enable_sde_telemetry: true,
+            incident_file: join(tmp, 'LIVE_INCIDENTS.md')
+        }));
+        app.use(express.json());
+
+        app.post('/admin/inject-failure', (req, res) => {
+            if (!req.interlock) return res.status(500).json({ error: 'missing interlock control plane' });
+            if (req.body?.mode === 'RESET') {
+                req.interlock.resetRuntimeState();
+                return res.json({ status: 'reset' });
+            }
+            return res.status(400).json({ error: 'Unknown mode' });
+        });
+
+        app.post('/work', async (req, res) => {
+            const delayMs = Number(req.query.delayMs || 0);
+            if (delayMs > 0) await new Promise(resolve => setTimeout(resolve, delayMs));
+            res.json({ status: 'done' });
+        });
+
+        server = app.listen(0);
+        await new Promise<void>(resolve => server?.once('listening', resolve));
+        const address = server.address();
+        if (!address || typeof address === 'string') throw new Error('expected tcp listener');
+        const baseUrl = `http://127.0.0.1:${address.port}`;
+
+        const initialHealthy = await postJson(`${baseUrl}/work`, {});
+        expect(initialHealthy.status).toBe(200);
+
+        const slow = await postJson(`${baseUrl}/work?delayMs=40`, {});
+        expect(slow.status).toBe(200);
+
+        const refused = await postJson(`${baseUrl}/work`, {});
+        expect(refused.status).toBe(503);
+        const refusedBody = await refused.json();
+        expect(refusedBody.refused).toBe(true);
+        expect(refusedBody.decision.law_hash).toBe(expectedLawHash);
+
+        const reset = await postJson(`${baseUrl}/admin/inject-failure`, { mode: 'RESET' });
+        expect(reset.status).toBe(200);
+        await expect(reset.json()).resolves.toEqual({ status: 'reset' });
+
+        const recovered = await postJson(`${baseUrl}/work`, {});
+        expect(recovered.status).toBe(200);
+        await expect(recovered.json()).resolves.toEqual({ status: 'done' });
+
+        const events = await readEventsEventually(eventsPath);
+        expect(events.some(event => event.kernel?.law_hash === expectedLawHash)).toBe(true);
+        expect(events.every(event => typeof event.kernel?.law_hash === 'string' && event.kernel.law_hash.length > 0)).toBe(true);
+    });
 });
 
 function postJson(url: string, body: unknown): Promise<Response> {
@@ -120,4 +199,53 @@ function postJson(url: string, body: unknown): Promise<Response> {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
     });
+}
+
+function makeLaw(parameters: Partial<Record<string, number>> = {}) {
+    return {
+        law_id: 'law-threshold-reset-test',
+        schema_version: '1.0.0',
+        domain: 'ollama',
+        hardware_fingerprint: null,
+        parameters: {
+            latency_threshold_ms: 20,
+            error_threshold_pct: 0.05,
+            recovery_timeout_ms: 60000,
+            probe_interval_ms: 5000,
+            confidence_floor: 0.5,
+            decay_rate: 0.1,
+            ...parameters
+        },
+        source: {
+            type: 'manual',
+            proposal_id: null,
+            created_at: '2026-05-06T00:00:00.000Z'
+        }
+    };
+}
+
+async function readEventsEventually(eventsPath: string): Promise<any[]> {
+    for (let i = 0; i < 50; i++) {
+        const events = readEvents(eventsPath);
+        if (events.length > 0) return events;
+        await new Promise(resolve => setTimeout(resolve, 20));
+    }
+    return readEvents(eventsPath);
+}
+
+function readEvents(eventsPath: string): any[] {
+    try {
+        return readFileSync(eventsPath, 'utf-8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map(line => JSON.parse(line));
+    } catch {
+        return [];
+    }
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
 }


### PR DESCRIPTION
## Summary

- Fixes the stuck-refusal recovery bug exposed by LawPack Recovery Characterization v1.
- Adds an explicit `resetRuntimeState()` handle on `req.interlock` for opt-in control-plane routes.
- RESET now clears all state that can keep threshold-induced refusal active:
  - failure injection
  - recorded failure signals
  - monitor confidence state
  - latency probe history
  - active incident state
  - recovery window state
  - current health-window metrics
- Updates the Express demo RESET route to use the shared runtime reset path.
- Keeps `/work` and `/chat` governed and does not broaden control-plane bypasses beyond existing `control_plane_paths` opt-in.
- Preserves runtime law-hash stamping from PR #56.
- Does not modify SDE.

## Root Cause

The previous RESET route cleared failure injection and called `monitor.reset()`, but threshold-induced refusal could remain active because latency probe samples and module-level incident/recovery state were not cleared. A slow request stayed in the latency window, so the monitor immediately recomputed confidence below the quality floor after reset.

## Tests Run

- `node.exe .\node_modules\typescript\bin\tsc --noEmit -p tsconfig.ci.json`
- `node.exe .\node_modules\tsx\dist\cli.mjs scripts\validation-tests.ts`
- `node.exe .\node_modules\tsx\dist\cli.mjs scripts\validate-law-loader.ts`
- `node.exe .\node_modules\vitest\vitest.mjs run test\runtimeLawStamp.test.ts`
- `node.exe .\node_modules\vitest\vitest.mjs run test\interlockExpress.control-plane.test.ts`

## Manual Proof

Using the candidate LawPack law from the runtime compatibility proof:

- law hash: `941efdba37865677`
- `latency_threshold_ms = 1900`
- slow request #1: HTTP 200, `2705 ms`
- slow request #2: HTTP 503 refusal
- RESET route: HTTP 200, `{ "status": "reset" }`
- post-RESET healthy `/work`: 3/3 HTTP 200
- emitted telemetry law hash: `941efdba37865677`
- SDE validate-log: `VALID`, `5/5` parsed, 100% required/recommended stamp coverage

## Safety

- Refusal behavior is not weakened.
- Thresholds are not raised.
- Validators are not weakened.
- SDE validator and LawPack artifacts are not modified.
- No promote/ship/import path was run.