### PR TITLE
feat: add bounded cold-start grace v1

### DIFF
--- a/packages/interlock-express/src/health-window.ts
+++ b/packages/interlock-express/src/health-window.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../services/events.types.ts';
 import { stampEvent } from '../../../services/kernel/eventStamp.ts';
 import { getJsonlSink } from './jsonl-sink.ts';
+import type { RuntimeGraceSnapshot } from './runtime-grace.ts';
 
 const DEFAULT_HEALTH_WINDOW_MS = 5000; // 5 seconds
 
@@ -22,6 +23,7 @@ export interface HealthWindowOptions {
         latency_threshold_ms: number;
         error_threshold_pct: number;
     };
+    getRuntimeGraceState?: () => RuntimeGraceSnapshot;
 }
 
 export interface MetricsCollector {
@@ -29,6 +31,7 @@ export interface MetricsCollector {
     errorCount: number;
     requestCount: number;
     windowStart: Date;
+    graceState: RuntimeGraceSnapshot | null;
 }
 
 /**
@@ -39,17 +42,21 @@ export function createMetricsCollector(): MetricsCollector {
         latencies: [],
         errorCount: 0,
         requestCount: 0,
-        windowStart: new Date()
+        windowStart: new Date(),
+        graceState: null
     };
 }
 
 /**
  * Record a request in the metrics collector
  */
-export function recordRequest(collector: MetricsCollector, latencyMs: number, isError: boolean): void {
+export function recordRequest(collector: MetricsCollector, latencyMs: number, isError: boolean, graceState?: RuntimeGraceSnapshot): void {
     collector.latencies.push(latencyMs);
     collector.requestCount++;
     if (isError) collector.errorCount++;
+    if (graceState && (graceState.grace_active || !collector.graceState)) {
+        collector.graceState = graceState;
+    }
 }
 
 /**
@@ -60,6 +67,7 @@ export function resetMetricsCollector(collector: MetricsCollector): void {
     collector.errorCount = 0;
     collector.requestCount = 0;
     collector.windowStart = new Date();
+    collector.graceState = null;
 }
 
 /**
@@ -86,7 +94,8 @@ function calculateMax(latencies: number[]): number {
 export function buildHealthWindowEvent(
     collector: MetricsCollector,
     domain: Domain,
-    thresholds: { latency_threshold_ms: number; error_threshold_pct: number }
+    thresholds: { latency_threshold_ms: number; error_threshold_pct: number },
+    runtimeGraceState?: RuntimeGraceSnapshot
 ): HealthWindowEvent {
     const now = new Date();
     const durationMs = now.getTime() - collector.windowStart.getTime();
@@ -97,12 +106,21 @@ export function buildHealthWindowEvent(
         ? collector.errorCount / collector.requestCount
         : 0;
 
+    const graceState = collector.graceState ?? runtimeGraceState;
+
     const event = {
         event_type: 'health_window',
         schema_version: '1.0.0',
         timestamp: now.toISOString(),
         domain,
         hardware_fingerprint: getHardwareFingerprint(),
+        runtime_phase: graceState?.runtime_phase,
+        grace_active: graceState?.grace_active,
+        grace_reason: graceState?.grace_reason,
+        grace_request_index: graceState?.grace_request_index,
+        grace_elapsed_ms: graceState?.grace_elapsed_ms,
+        active_latency_threshold_ms: graceState?.active_latency_threshold_ms,
+        steady_state_latency_threshold_ms: graceState?.steady_state_latency_threshold_ms,
         window: {
             start: collector.windowStart.toISOString(),
             end: now.toISOString(),
@@ -116,7 +134,9 @@ export function buildHealthWindowEvent(
         },
         thresholds: {
             latency_threshold_ms: thresholds.latency_threshold_ms,
-            error_threshold_pct: thresholds.error_threshold_pct
+            error_threshold_pct: thresholds.error_threshold_pct,
+            active_latency_threshold_ms: graceState?.active_latency_threshold_ms,
+            steady_state_latency_threshold_ms: graceState?.steady_state_latency_threshold_ms
         },
         margin: latencyP95 > 0 ? {
             latency_headroom_ms: thresholds.latency_threshold_ms - latencyP95,
@@ -145,7 +165,7 @@ export function startHealthWindowEmitter(options: HealthWindowOptions): {
 
     const interval = setInterval(() => {
         // Build and emit the health window event
-        const event = buildHealthWindowEvent(collector, options.domain, options.thresholds);
+        const event = buildHealthWindowEvent(collector, options.domain, options.thresholds, options.getRuntimeGraceState?.());
         sink.emit(event);
 
         // Reset collector for next window without invalidating middleware references

--- a/packages/interlock-express/src/index.ts
+++ b/packages/interlock-express/src/index.ts
@@ -10,6 +10,7 @@ import { Domain } from '../../../services/events.types';
 import { initKernelStamp } from '../../../services/kernel/eventStamp';
 import type { RuntimeLawProvenance } from '../../../services/kernel/eventStamp';
 import { resetJsonlSink } from './jsonl-sink';
+import { RuntimeGraceTracker } from './runtime-grace';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 
@@ -69,7 +70,7 @@ export function interlockExpress(options: InterlockOptions = {}) {
     const enableSdeTelemetry = options.enable_sde_telemetry ?? true;
     const lawResult = loadLaw(domain);
     const qualityFloor = options.quality_floor ?? lawResult.parameters.confidence_floor ?? 0.5;
-    const latencyThresholdMs = lawResult.parameters.latency_threshold_ms || 500;
+    const latencyThresholdMs = lawResult.parameters.steady_state_latency_threshold_ms ?? lawResult.parameters.latency_threshold_ms ?? 500;
     const errorThresholdPct = lawResult.parameters.error_threshold_pct || 0.05;
     const failureClass = options.failure_class || 'Forced application error (non-user, non-network)';
     const logFile = options.incident_file || path.resolve(process.cwd(), 'docs/LIVE_INCIDENTS.md');
@@ -77,6 +78,11 @@ export function interlockExpress(options: InterlockOptions = {}) {
     const latencyProbe = new LatencyProbe();
     const failureInjector = new FailureInjector();
     const monitor = new ConfidenceMonitor(latencyProbe, failureInjector, qualityFloor, latencyThresholdMs);
+    const runtimeGrace = new RuntimeGraceTracker({
+        coldStartGraceRequests: lawResult.parameters.cold_start_grace_requests ?? 0,
+        coldStartGraceMs: lawResult.parameters.cold_start_grace_ms ?? 0,
+        steadyStateLatencyThresholdMs: latencyThresholdMs
+    });
     const sink: IncidentSink = new FileIncidentSink(logFile);
     const controlPlanePaths = new Set(options.control_plane_paths ?? []);
     const resetRuntimeState = () => {
@@ -84,6 +90,7 @@ export function interlockExpress(options: InterlockOptions = {}) {
         failureInjector.clear();
         latencyProbe.clear();
         monitor.reset();
+        runtimeGrace.reset();
         activeIncident = null;
         recoveryWindowStart = null;
         if (metricsCollector) resetMetricsCollector(metricsCollector);
@@ -94,7 +101,11 @@ export function interlockExpress(options: InterlockOptions = {}) {
             options.workload ?? { model_id: 'gemma3:1b', provider: domain },
             buildRuntimeLawProvenance(domain, lawResult)
         );
-        const emitter = startHealthWindowEmitter({ domain, thresholds: { latency_threshold_ms: latencyThresholdMs, error_threshold_pct: errorThresholdPct } });
+        const emitter = startHealthWindowEmitter({
+            domain,
+            thresholds: { latency_threshold_ms: latencyThresholdMs, error_threshold_pct: errorThresholdPct },
+            getRuntimeGraceState: () => runtimeGrace.snapshotNow()
+        });
         metricsCollector = emitter.collector;
         healthWindowStopper = emitter.stop;
     }
@@ -135,17 +146,22 @@ export function interlockExpress(options: InterlockOptions = {}) {
             return next();
         }
 
+        const graceState = runtimeGrace.startRequest();
         const startTime = Date.now();
         res.on('finish', () => {
             const duration = Date.now() - startTime;
-            latencyProbe.record({ timestamp: Date.now(), latencyMs: duration, operation: 'query' });
+            const isError = res.statusCode >= 500 && res.statusCode !== 503;
+            const shouldSuppressLatencyProbe = graceState.grace_active && !isError && res.statusCode < 500;
+            if (!shouldSuppressLatencyProbe) {
+                latencyProbe.record({ timestamp: Date.now(), latencyMs: duration, operation: 'query' });
+            }
             if (metricsCollector) {
-                const isError = res.statusCode >= 500 && res.statusCode !== 503;
-                if (!(dryRun && (res.statusCode === 503 || res.statusCode === 429))) recordRequest(metricsCollector, duration, isError);
+                if (!(dryRun && (res.statusCode === 503 || res.statusCode === 429))) recordRequest(metricsCollector, duration, isError, graceState);
             }
             if (res.statusCode >= 500 && res.statusCode !== 503) {
                 failureInjector.recordSignal({ timestamp: Date.now(), type: 'error', severity: 'high', message: `HTTP ${res.statusCode}` });
             }
+            runtimeGrace.finishRequest();
         });
 
         monitor.update();
@@ -168,7 +184,7 @@ export function interlockExpress(options: InterlockOptions = {}) {
                 activeIncident = { start: Date.now(), events: [] };
                 sink.logEvent({ incidentId: String(incidentId).padStart(3, '0'), trigger: 'Confidence < Quality Floor', action: 'Traffic Refusal', details: 'Initial refusal triggered', recoveryTime: 0, confidence: monitor.getConfidence(), failureClass });
                 if (enableSdeTelemetry) {
-                    emitInterventionEvent({ domain, trigger: { interlockTrigger: 'confidence_floor_breach', thresholdMs: latencyThresholdMs, observedMs: latencyProbe.getStats().meanMs || 0, confidence: monitor.getConfidence() }, action: { interlockAction: 'refuse', priorState: 'closed', newState: 'open' }, recovery: { timeMs: 0, probeAttempts: 0, finalState: 'open' }, context: { qualityFloorHit: true } });
+                    emitInterventionEvent({ domain, trigger: { interlockTrigger: 'confidence_floor_breach', thresholdMs: latencyThresholdMs, observedMs: latencyProbe.getStats().meanMs || 0, confidence: monitor.getConfidence() }, action: { interlockAction: 'refuse', priorState: 'closed', newState: 'open' }, recovery: { timeMs: 0, probeAttempts: 0, finalState: 'open' }, context: { qualityFloorHit: true }, grace: graceState });
                 }
             }
             recoveryWindowStart = null;
@@ -179,7 +195,7 @@ export function interlockExpress(options: InterlockOptions = {}) {
                 const duration = (Date.now() - activeIncident.start) / 1000;
                 const recoveryTimeMs = Date.now() - activeIncident.start;
                 sink.logEvent({ incidentId: `${String(incidentId).padStart(3, '0')}-A`, trigger: 'Recovery', action: 'Traffic Refusal / Degraded Mode', details: 'System refused traffic to prevent collapse', recoveryTime: duration, confidence: monitor.getConfidence(), failureClass });
-                if (enableSdeTelemetry) emitInterventionEvent({ domain, trigger: { interlockTrigger: 'recovery', thresholdMs: latencyThresholdMs, observedMs: latencyProbe.getStats().meanMs || 0, confidence: monitor.getConfidence() }, action: { interlockAction: 'circuit_close', priorState: 'open', newState: 'closed' }, recovery: { timeMs: recoveryTimeMs, probeAttempts: 1, finalState: 'closed' } });
+                if (enableSdeTelemetry) emitInterventionEvent({ domain, trigger: { interlockTrigger: 'recovery', thresholdMs: latencyThresholdMs, observedMs: latencyProbe.getStats().meanMs || 0, confidence: monitor.getConfidence() }, action: { interlockAction: 'circuit_close', priorState: 'open', newState: 'closed' }, recovery: { timeMs: recoveryTimeMs, probeAttempts: 1, finalState: 'closed' }, grace: graceState });
                 activeIncident = null; recoveryWindowStart = null;
             }
         }

--- a/packages/interlock-express/src/intervention-emitter.ts
+++ b/packages/interlock-express/src/intervention-emitter.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../services/events.types.ts';
 import { stampEvent } from '../../../services/kernel/eventStamp.ts';
 import { getJsonlSink } from './jsonl-sink.ts';
+import type { RuntimeGraceSnapshot } from './runtime-grace.ts';
 
 export interface InterventionEventData {
     domain: Domain;
@@ -41,6 +42,7 @@ export interface InterventionEventData {
         trustDecayRate?: number;
         windowDurationMs?: number;
     };
+    grace?: RuntimeGraceSnapshot;
 }
 
 /**
@@ -53,6 +55,13 @@ export function emitInterventionEvent(data: InterventionEventData): void {
         timestamp: new Date().toISOString(),
         domain: data.domain,
         hardware_fingerprint: getHardwareFingerprint(),
+        runtime_phase: data.grace?.runtime_phase,
+        grace_active: data.grace?.grace_active,
+        grace_reason: data.grace?.grace_reason,
+        grace_request_index: data.grace?.grace_request_index,
+        grace_elapsed_ms: data.grace?.grace_elapsed_ms,
+        active_latency_threshold_ms: data.grace?.active_latency_threshold_ms,
+        steady_state_latency_threshold_ms: data.grace?.steady_state_latency_threshold_ms,
         trigger: {
             type: mapToSDETriggerType(data.trigger.interlockTrigger),
             threshold_ms: data.trigger.thresholdMs,

--- a/packages/interlock-express/src/runtime-grace.ts
+++ b/packages/interlock-express/src/runtime-grace.ts
@@ -1,0 +1,111 @@
+export type RuntimePhase = 'cold_start' | 'steady_state' | 'post_reset' | 'unknown';
+
+export interface ColdStartGraceConfig {
+    coldStartGraceRequests: number;
+    coldStartGraceMs: number;
+    steadyStateLatencyThresholdMs: number;
+}
+
+export interface RuntimeGraceSnapshot {
+    runtime_phase: RuntimePhase;
+    grace_active: boolean;
+    grace_reason: string;
+    grace_request_index: number;
+    grace_elapsed_ms: number;
+    active_latency_threshold_ms: number;
+    steady_state_latency_threshold_ms: number;
+}
+
+interface ActiveRequest {
+    graceActive: boolean;
+    requestIndex: number;
+}
+
+export class RuntimeGraceTracker {
+    private readonly initializedAt = Date.now();
+    private requestCount = 0;
+    private coldStartClosed = false;
+    private postResetPending = false;
+
+    constructor(private readonly config: ColdStartGraceConfig) { }
+
+    startRequest(): RuntimeGraceSnapshot {
+        this.expireColdStartIfNeeded();
+
+        const phase = this.currentPhase();
+        const nextRequestIndex = this.requestCount + 1;
+        const graceActive = this.isColdStartGraceActive(nextRequestIndex);
+
+        this.requestCount = nextRequestIndex;
+        if (this.requestCount >= this.config.coldStartGraceRequests) {
+            this.coldStartClosed = true;
+        }
+
+        return this.snapshot(phase, {
+            graceActive,
+            requestIndex: nextRequestIndex
+        });
+    }
+
+    finishRequest(): void {
+        if (this.postResetPending) {
+            this.postResetPending = false;
+        }
+        this.expireColdStartIfNeeded();
+    }
+
+    reset(): void {
+        this.coldStartClosed = true;
+        this.postResetPending = true;
+    }
+
+    snapshotNow(): RuntimeGraceSnapshot {
+        this.expireColdStartIfNeeded();
+        return this.snapshot(this.currentPhase(), {
+            graceActive: false,
+            requestIndex: this.requestCount
+        });
+    }
+
+    private currentPhase(): RuntimePhase {
+        if (this.postResetPending) return 'post_reset';
+        if (!this.coldStartClosed && this.config.coldStartGraceRequests > 0 && this.config.coldStartGraceMs > 0) {
+            return 'cold_start';
+        }
+        return 'steady_state';
+    }
+
+    private isColdStartGraceActive(nextRequestIndex: number): boolean {
+        return this.currentPhase() === 'cold_start'
+            && nextRequestIndex <= this.config.coldStartGraceRequests
+            && this.elapsedMs() <= this.config.coldStartGraceMs;
+    }
+
+    private expireColdStartIfNeeded(): void {
+        if (this.coldStartClosed) return;
+        if (this.config.coldStartGraceRequests <= 0 || this.config.coldStartGraceMs <= 0) {
+            this.coldStartClosed = true;
+            return;
+        }
+        if (this.requestCount >= this.config.coldStartGraceRequests || this.elapsedMs() > this.config.coldStartGraceMs) {
+            this.coldStartClosed = true;
+        }
+    }
+
+    private snapshot(phase: RuntimePhase, request: ActiveRequest): RuntimeGraceSnapshot {
+        const graceReason = request.graceActive ? 'cold_start_bounded' : 'none';
+        return {
+            runtime_phase: phase,
+            grace_active: request.graceActive,
+            grace_reason: graceReason,
+            grace_request_index: request.graceActive ? request.requestIndex : 0,
+            grace_elapsed_ms: phase === 'cold_start' ? this.elapsedMs() : 0,
+            active_latency_threshold_ms: this.config.steadyStateLatencyThresholdMs,
+            steady_state_latency_threshold_ms: this.config.steadyStateLatencyThresholdMs
+        };
+    }
+
+    private elapsedMs(): number {
+        return Date.now() - this.initializedAt;
+    }
+}

--- a/schemas/interlock_event.schema.json
+++ b/schemas/interlock_event.schema.json
@@ -53,6 +53,29 @@
                 "hardware_fingerprint": {
                     "type": "string"
                 },
+                "runtime_phase": {
+                    "$ref": "#/definitions/runtime_phase"
+                },
+                "grace_active": {
+                    "type": "boolean"
+                },
+                "grace_reason": {
+                    "type": "string"
+                },
+                "grace_request_index": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "grace_elapsed_ms": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "active_latency_threshold_ms": {
+                    "type": "number"
+                },
+                "steady_state_latency_threshold_ms": {
+                    "type": "number"
+                },
                 "kernel": {
                     "$ref": "#/definitions/kernel_stamp"
                 },
@@ -208,6 +231,29 @@
                 "hardware_fingerprint": {
                     "type": "string"
                 },
+                "runtime_phase": {
+                    "$ref": "#/definitions/runtime_phase"
+                },
+                "grace_active": {
+                    "type": "boolean"
+                },
+                "grace_reason": {
+                    "type": "string"
+                },
+                "grace_request_index": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "grace_elapsed_ms": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "active_latency_threshold_ms": {
+                    "type": "number"
+                },
+                "steady_state_latency_threshold_ms": {
+                    "type": "number"
+                },
                 "kernel": {
                     "$ref": "#/definitions/kernel_stamp"
                 },
@@ -272,6 +318,12 @@
                             "type": "number"
                         },
                         "error_threshold_pct": {
+                            "type": "number"
+                        },
+                        "active_latency_threshold_ms": {
+                            "type": "number"
+                        },
+                        "steady_state_latency_threshold_ms": {
                             "type": "number"
                         }
                     }
@@ -338,6 +390,15 @@
                     "type": "string"
                 }
             }
+        },
+        "runtime_phase": {
+            "type": "string",
+            "enum": [
+                "cold_start",
+                "steady_state",
+                "post_reset",
+                "unknown"
+            ]
         }
     }
 }

--- a/services/events.types.ts
+++ b/services/events.types.ts
@@ -35,6 +35,13 @@ interface EventBase {
     physics_hash?: string;
     workload?: SDEWorkload;
     hardware_fingerprint: string;
+    runtime_phase?: 'cold_start' | 'steady_state' | 'post_reset' | 'unknown';
+    grace_active?: boolean;
+    grace_reason?: string;
+    grace_request_index?: number;
+    grace_elapsed_ms?: number;
+    active_latency_threshold_ms?: number;
+    steady_state_latency_threshold_ms?: number;
 }
 
 export interface SDEWorkload {
@@ -105,6 +112,8 @@ export interface HealthMetrics {
 export interface HealthThresholds {
     latency_threshold_ms: number;
     error_threshold_pct: number;
+    active_latency_threshold_ms?: number;
+    steady_state_latency_threshold_ms?: number;
 }
 
 export interface HealthMargin {

--- a/services/law-loader.ts
+++ b/services/law-loader.ts
@@ -133,6 +133,9 @@ export function loadLaw(domain: string): LoadLawResult {
         // Otherwise treat as Full Law if 'parameters' exists
         else if (law.parameters) {
             params.latency_threshold_ms = law.parameters.latency_threshold_ms ?? DEFAULT_LAW_PARAMETERS.latency_threshold_ms;
+            params.cold_start_grace_requests = law.parameters.cold_start_grace_requests ?? DEFAULT_LAW_PARAMETERS.cold_start_grace_requests;
+            params.cold_start_grace_ms = law.parameters.cold_start_grace_ms ?? DEFAULT_LAW_PARAMETERS.cold_start_grace_ms;
+            params.steady_state_latency_threshold_ms = law.parameters.steady_state_latency_threshold_ms ?? params.latency_threshold_ms;
             params.error_threshold_pct = law.parameters.error_threshold_pct ?? DEFAULT_LAW_PARAMETERS.error_threshold_pct;
             params.recovery_timeout_ms = law.parameters.recovery_timeout_ms ?? DEFAULT_LAW_PARAMETERS.recovery_timeout_ms;
             params.probe_interval_ms = law.parameters.probe_interval_ms ?? DEFAULT_LAW_PARAMETERS.probe_interval_ms;
@@ -140,10 +143,26 @@ export function loadLaw(domain: string): LoadLawResult {
             params.decay_rate = law.parameters.decay_rate ?? DEFAULT_LAW_PARAMETERS.decay_rate;
         }
 
+        params.steady_state_latency_threshold_ms = params.steady_state_latency_threshold_ms ?? params.latency_threshold_ms;
+        params.cold_start_grace_requests = Math.floor(params.cold_start_grace_requests ?? 0);
+        params.cold_start_grace_ms = Math.floor(params.cold_start_grace_ms ?? 0);
+
         // Bounds checking
         if (params.latency_threshold_ms < 10 || params.latency_threshold_ms > 60000) {
             warnings.push(`latency_threshold_ms out of bounds, clamping.`);
             params.latency_threshold_ms = Math.max(10, Math.min(60000, params.latency_threshold_ms));
+        }
+        if (params.steady_state_latency_threshold_ms < 10 || params.steady_state_latency_threshold_ms > 60000) {
+            warnings.push(`steady_state_latency_threshold_ms out of bounds, clamping.`);
+            params.steady_state_latency_threshold_ms = Math.max(10, Math.min(60000, params.steady_state_latency_threshold_ms));
+        }
+        if (params.cold_start_grace_requests < 0 || params.cold_start_grace_requests > 100) {
+            warnings.push(`cold_start_grace_requests out of bounds, clamping.`);
+            params.cold_start_grace_requests = Math.max(0, Math.min(100, params.cold_start_grace_requests));
+        }
+        if (params.cold_start_grace_ms < 0 || params.cold_start_grace_ms > 600000) {
+            warnings.push(`cold_start_grace_ms out of bounds, clamping.`);
+            params.cold_start_grace_ms = Math.max(0, Math.min(600000, params.cold_start_grace_ms));
         }
         if (params.confidence_floor < 0 || params.confidence_floor > 1) {
             warnings.push(`confidence_floor out of bounds, clamping.`);
@@ -203,7 +222,7 @@ export function mapLawToCircuitBreakerConfig(params: LawParameters): Partial<{
     hazardThreshold: number;
 }> {
     return {
-        latencyThresholdMs: params.latency_threshold_ms,
+        latencyThresholdMs: params.steady_state_latency_threshold_ms ?? params.latency_threshold_ms,
         // Map error_threshold_pct to hazardThreshold (inverse relationship)
         hazardThreshold: 1 - params.error_threshold_pct
     };

--- a/services/law.types.ts
+++ b/services/law.types.ts
@@ -13,6 +13,15 @@ export interface LawParameters {
     /** Latency threshold in milliseconds */
     latency_threshold_ms: number;
 
+    /** Optional bounded startup grace request count */
+    cold_start_grace_requests?: number;
+
+    /** Optional bounded startup grace duration */
+    cold_start_grace_ms?: number;
+
+    /** Optional steady-state threshold once startup grace expires */
+    steady_state_latency_threshold_ms?: number;
+
     /** Error rate threshold as percentage (0.05 = 5%) */
     error_threshold_pct: number;
 
@@ -64,6 +73,8 @@ export interface LawFile {
 
 export const DEFAULT_LAW_PARAMETERS: LawParameters = {
     latency_threshold_ms: 500,
+    cold_start_grace_requests: 0,
+    cold_start_grace_ms: 0,
     error_threshold_pct: 0.05,
     recovery_timeout_ms: 60000,
     probe_interval_ms: 5000,

--- a/test/interlockExpress.cold-start-grace.test.ts
+++ b/test/interlockExpress.cold-start-grace.test.ts
@@ -14,6 +14,9 @@ const rateLimiter = rateLimit({
     standardHeaders: true,
     legacyHeaders: false
 });
+const TEST_SLOW_DELAY_MS = 40;
+const TEST_WAIT_FOR_GRACE_EXPIRY_MS = 10;
+const TEST_EVENT_POLL_MS = 20;
 
 describe('interlockExpress bounded cold-start grace', () => {
     let server: Server | null = null;
@@ -43,7 +46,7 @@ describe('interlockExpress bounded cold-start grace', () => {
 
     it('preserves default threshold poisoning behavior when grace fields are absent', async () => {
         const app = await startApp(makeLaw({ latency_threshold_ms: 20, confidence_floor: 0.5 }));
-        const slow = await postJson(`${app.baseUrl}/work?delayMs=40`, {});
+        const slow = await postJson(`${app.baseUrl}/work-slow`, {});
         expect(slow.status).toBe(200);
 
         const refused = await postJson(`${app.baseUrl}/work`, {});
@@ -60,7 +63,7 @@ describe('interlockExpress bounded cold-start grace', () => {
             confidence_floor: 0.5
         }));
 
-        const coldSlow = await postJson(`${app.baseUrl}/work?delayMs=40`, {});
+        const coldSlow = await postJson(`${app.baseUrl}/work-slow`, {});
         expect(coldSlow.status).toBe(200);
 
         const nextHealthy = await postJson(`${app.baseUrl}/work`, {});
@@ -76,10 +79,10 @@ describe('interlockExpress bounded cold-start grace', () => {
             confidence_floor: 0.5
         }));
 
-        expect((await postJson(`${app.baseUrl}/work?delayMs=40`, {})).status).toBe(200);
+        expect((await postJson(`${app.baseUrl}/work-slow`, {})).status).toBe(200);
         expect((await postJson(`${app.baseUrl}/work`, {})).status).toBe(200);
 
-        const postGraceSlow = await postJson(`${app.baseUrl}/work?delayMs=40`, {});
+        const postGraceSlow = await postJson(`${app.baseUrl}/work-slow`, {});
         expect(postGraceSlow.status).toBe(200);
 
         const refused = await postJson(`${app.baseUrl}/work`, {});
@@ -95,9 +98,9 @@ describe('interlockExpress bounded cold-start grace', () => {
             confidence_floor: 0.5
         }));
 
-        await delay(10);
+        await delay(TEST_WAIT_FOR_GRACE_EXPIRY_MS);
 
-        expect((await postJson(`${app.baseUrl}/work?delayMs=40`, {})).status).toBe(200);
+        expect((await postJson(`${app.baseUrl}/work-slow`, {})).status).toBe(200);
         const refused = await postJson(`${app.baseUrl}/work`, {});
         expect(refused.status).toBe(503);
     });
@@ -129,7 +132,7 @@ describe('interlockExpress bounded cold-start grace', () => {
             confidence_floor: 0.5
         }), { telemetry: true });
 
-        expect((await postJson(`${app.baseUrl}/work?delayMs=40`, {})).status).toBe(200);
+        expect((await postJson(`${app.baseUrl}/work-slow`, {})).status).toBe(200);
 
         const events = await readEventsEventually(app.eventsPath, events =>
             events.some(event => event.event_type === 'health_window' && event.metrics?.request_count > 0)
@@ -156,13 +159,13 @@ describe('interlockExpress bounded cold-start grace', () => {
             confidence_floor: 0.5
         }), { controlPlane: true });
 
-        expect((await postJson(`${app.baseUrl}/work?delayMs=40`, {})).status).toBe(200);
+        expect((await postJson(`${app.baseUrl}/work-slow`, {})).status).toBe(200);
         expect((await postJson(`${app.baseUrl}/work`, {})).status).toBe(200);
 
         const reset = await postJson(`${app.baseUrl}/admin/inject-failure`, { mode: 'RESET' });
         expect(reset.status).toBe(200);
 
-        expect((await postJson(`${app.baseUrl}/work?delayMs=40`, {})).status).toBe(200);
+        expect((await postJson(`${app.baseUrl}/work-slow`, {})).status).toBe(200);
         const refused = await postJson(`${app.baseUrl}/work`, {});
         expect(refused.status).toBe(503);
     });
@@ -204,9 +207,12 @@ describe('interlockExpress bounded cold-start grace', () => {
             return res.status(400).json({ error: 'Unknown mode' });
         });
 
-        app.post('/work', async (req, res) => {
-            const delayMs = Number(req.query.delayMs || 0);
-            if (delayMs > 0) await delay(delayMs);
+        app.post('/work', (_req, res) => {
+            res.json({ status: 'done' });
+        });
+
+        app.post('/work-slow', async (_req, res) => {
+            await delay(TEST_SLOW_DELAY_MS);
             res.json({ status: 'done' });
         });
 
@@ -258,7 +264,7 @@ async function readEventsEventually(eventsPath: string, predicate: (events: any[
     for (let i = 0; i < 50; i++) {
         const events = readEvents(eventsPath);
         if (predicate(events)) return events;
-        await delay(20);
+        await delay(TEST_EVENT_POLL_MS);
     }
     return readEvents(eventsPath);
 }

--- a/test/interlockExpress.cold-start-grace.test.ts
+++ b/test/interlockExpress.cold-start-grace.test.ts
@@ -1,0 +1,285 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Server } from 'node:http';
+import { interlockExpress, stopSdeTelemetry } from '../packages/interlock-express/src/index.ts';
+import { loadLaw } from '../services/law-loader.ts';
+
+const rateLimiter = rateLimit({
+    windowMs: 60_000,
+    limit: 100,
+    standardHeaders: true,
+    legacyHeaders: false
+});
+
+describe('interlockExpress bounded cold-start grace', () => {
+    let server: Server | null = null;
+    const originalLawPath = process.env.INTERLOCK_LAW_PATH;
+    const originalEventsPath = process.env.INTERLOCK_EVENTS_PATH;
+    const originalHealthWindowMs = process.env.INTERLOCK_HEALTH_WINDOW_MS;
+    const tempDirsForCleanup: string[] = [];
+
+    afterEach(async () => {
+        stopSdeTelemetry();
+        if (server) {
+            await new Promise<void>((resolve, reject) => {
+                server?.close(error => error ? reject(error) : resolve());
+            });
+            server = null;
+        }
+
+        restoreEnv('INTERLOCK_LAW_PATH', originalLawPath);
+        restoreEnv('INTERLOCK_EVENTS_PATH', originalEventsPath);
+        restoreEnv('INTERLOCK_HEALTH_WINDOW_MS', originalHealthWindowMs);
+
+        for (const dir of tempDirsForCleanup) {
+            rmSync(dir, { recursive: true, force: true });
+        }
+        tempDirsForCleanup.length = 0;
+    });
+
+    it('preserves default threshold poisoning behavior when grace fields are absent', async () => {
+        const app = await startApp(makeLaw({ latency_threshold_ms: 20, confidence_floor: 0.5 }));
+        const slow = await postJson(`${app.baseUrl}/work?delayMs=40`, {});
+        expect(slow.status).toBe(200);
+
+        const refused = await postJson(`${app.baseUrl}/work`, {});
+        expect(refused.status).toBe(503);
+        await expect(refused.json()).resolves.toMatchObject({ refused: true });
+    });
+
+    it('prevents startup false refusal after one cold slow healthy request', async () => {
+        const app = await startApp(makeLaw({
+            latency_threshold_ms: 20,
+            steady_state_latency_threshold_ms: 20,
+            cold_start_grace_requests: 1,
+            cold_start_grace_ms: 10_000,
+            confidence_floor: 0.5
+        }));
+
+        const coldSlow = await postJson(`${app.baseUrl}/work?delayMs=40`, {});
+        expect(coldSlow.status).toBe(200);
+
+        const nextHealthy = await postJson(`${app.baseUrl}/work`, {});
+        expect(nextHealthy.status).toBe(200);
+    });
+
+    it('expires grace after request count and still refuses slow traffic after grace', async () => {
+        const app = await startApp(makeLaw({
+            latency_threshold_ms: 20,
+            steady_state_latency_threshold_ms: 20,
+            cold_start_grace_requests: 1,
+            cold_start_grace_ms: 10_000,
+            confidence_floor: 0.5
+        }));
+
+        expect((await postJson(`${app.baseUrl}/work?delayMs=40`, {})).status).toBe(200);
+        expect((await postJson(`${app.baseUrl}/work`, {})).status).toBe(200);
+
+        const postGraceSlow = await postJson(`${app.baseUrl}/work?delayMs=40`, {});
+        expect(postGraceSlow.status).toBe(200);
+
+        const refused = await postJson(`${app.baseUrl}/work`, {});
+        expect(refused.status).toBe(503);
+    });
+
+    it('expires grace after time window', async () => {
+        const app = await startApp(makeLaw({
+            latency_threshold_ms: 20,
+            steady_state_latency_threshold_ms: 20,
+            cold_start_grace_requests: 10,
+            cold_start_grace_ms: 1,
+            confidence_floor: 0.5
+        }));
+
+        await delay(10);
+
+        expect((await postJson(`${app.baseUrl}/work?delayMs=40`, {})).status).toBe(200);
+        const refused = await postJson(`${app.baseUrl}/work`, {});
+        expect(refused.status).toBe(503);
+    });
+
+    it('does not suppress failure-injection refusal during grace', async () => {
+        const app = await startApp(makeLaw({
+            latency_threshold_ms: 20,
+            steady_state_latency_threshold_ms: 20,
+            cold_start_grace_requests: 10,
+            cold_start_grace_ms: 10_000,
+            confidence_floor: 0.8
+        }), { controlPlane: true });
+
+        expect((await postJson(`${app.baseUrl}/admin/inject-failure`, { mode: 'FORCE_ERROR' })).status).toBe(200);
+        expect((await postJson(`${app.baseUrl}/work`, {})).status).toBe(500);
+        expect((await postJson(`${app.baseUrl}/work`, {})).status).toBe(500);
+        expect((await postJson(`${app.baseUrl}/work`, {})).status).toBe(500);
+
+        const refused = await postJson(`${app.baseUrl}/work`, {});
+        expect(refused.status).toBe(503);
+    });
+
+    it('emits grace telemetry fields with the active law hash', async () => {
+        const app = await startApp(makeLaw({
+            latency_threshold_ms: 20,
+            steady_state_latency_threshold_ms: 20,
+            cold_start_grace_requests: 1,
+            cold_start_grace_ms: 10_000,
+            confidence_floor: 0.5
+        }), { telemetry: true });
+
+        expect((await postJson(`${app.baseUrl}/work?delayMs=40`, {})).status).toBe(200);
+
+        const events = await readEventsEventually(app.eventsPath, events =>
+            events.some(event => event.event_type === 'health_window' && event.metrics?.request_count > 0)
+        );
+        const healthWindow = events.find(event => event.event_type === 'health_window' && event.metrics?.request_count > 0);
+        expect(healthWindow).toBeTruthy();
+        expect(healthWindow.kernel.law_hash).toBe(app.expectedLawHash);
+        expect(healthWindow.runtime_phase).toBe('cold_start');
+        expect(healthWindow.grace_active).toBe(true);
+        expect(healthWindow.grace_reason).toBe('cold_start_bounded');
+        expect(healthWindow.grace_request_index).toBe(1);
+        expect(healthWindow.active_latency_threshold_ms).toBe(20);
+        expect(healthWindow.steady_state_latency_threshold_ms).toBe(20);
+        expect(healthWindow.thresholds.active_latency_threshold_ms).toBe(20);
+        expect(healthWindow.workload.model_id).toBe('gemma3:1b');
+    });
+
+    it('reset clears runtime state without adding reset grace in v1', async () => {
+        const app = await startApp(makeLaw({
+            latency_threshold_ms: 20,
+            steady_state_latency_threshold_ms: 20,
+            cold_start_grace_requests: 1,
+            cold_start_grace_ms: 10_000,
+            confidence_floor: 0.5
+        }), { controlPlane: true });
+
+        expect((await postJson(`${app.baseUrl}/work?delayMs=40`, {})).status).toBe(200);
+        expect((await postJson(`${app.baseUrl}/work`, {})).status).toBe(200);
+
+        const reset = await postJson(`${app.baseUrl}/admin/inject-failure`, { mode: 'RESET' });
+        expect(reset.status).toBe(200);
+
+        expect((await postJson(`${app.baseUrl}/work?delayMs=40`, {})).status).toBe(200);
+        const refused = await postJson(`${app.baseUrl}/work`, {});
+        expect(refused.status).toBe(503);
+    });
+
+    async function startApp(
+        law: ReturnType<typeof makeLaw>,
+        options: { telemetry?: boolean; controlPlane?: boolean } = {}
+    ): Promise<{ baseUrl: string; eventsPath: string; expectedLawHash: string }> {
+        const tmp = mkdtempSync(join(tmpdir(), 'interlock-cold-start-grace-'));
+        tempDirsForCleanup.push(tmp);
+        const lawPath = join(tmp, 'law.json');
+        const eventsPath = join(tmp, 'events.jsonl');
+        writeFileSync(lawPath, JSON.stringify(law, null, 2));
+
+        process.env.INTERLOCK_LAW_PATH = lawPath;
+        process.env.INTERLOCK_EVENTS_PATH = eventsPath;
+        process.env.INTERLOCK_HEALTH_WINDOW_MS = '20';
+        const expectedLawHash = loadLaw('ollama').lawHash;
+
+        const app = express();
+        app.use(rateLimiter);
+        app.use(interlockExpress({
+            control_plane_paths: options.controlPlane ? ['/admin/inject-failure'] : [],
+            enable_sde_telemetry: options.telemetry ?? false,
+            incident_file: join(tmp, 'LIVE_INCIDENTS.md')
+        }));
+        app.use(express.json());
+
+        app.post('/admin/inject-failure', (req, res) => {
+            if (!req.interlock) return res.status(500).json({ error: 'missing interlock control plane' });
+            if (req.body?.mode === 'FORCE_ERROR') {
+                req.interlock.failureInjector.enableInjection(1.0);
+                return res.json({ status: 'injected' });
+            }
+            if (req.body?.mode === 'RESET') {
+                req.interlock.resetRuntimeState();
+                return res.json({ status: 'reset' });
+            }
+            return res.status(400).json({ error: 'Unknown mode' });
+        });
+
+        app.post('/work', async (req, res) => {
+            const delayMs = Number(req.query.delayMs || 0);
+            if (delayMs > 0) await delay(delayMs);
+            res.json({ status: 'done' });
+        });
+
+        server = app.listen(0);
+        await new Promise<void>(resolve => server?.once('listening', resolve));
+        const address = server.address();
+        if (!address || typeof address === 'string') throw new Error('expected tcp listener');
+
+        return {
+            baseUrl: `http://127.0.0.1:${address.port}`,
+            eventsPath,
+            expectedLawHash
+        };
+    }
+});
+
+function postJson(url: string, body: unknown): Promise<Response> {
+    return fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+}
+
+function makeLaw(parameters: Partial<Record<string, number>> = {}) {
+    return {
+        law_id: 'law-cold-start-grace-test',
+        schema_version: '1.0.0',
+        domain: 'ollama',
+        hardware_fingerprint: null,
+        parameters: {
+            latency_threshold_ms: 20,
+            error_threshold_pct: 0.05,
+            recovery_timeout_ms: 60000,
+            probe_interval_ms: 5000,
+            confidence_floor: 0.5,
+            decay_rate: 0.1,
+            ...parameters
+        },
+        source: {
+            type: 'manual',
+            proposal_id: null,
+            created_at: '2026-05-07T00:00:00.000Z'
+        }
+    };
+}
+
+async function readEventsEventually(eventsPath: string, predicate: (events: any[]) => boolean = events => events.length > 0): Promise<any[]> {
+    for (let i = 0; i < 50; i++) {
+        const events = readEvents(eventsPath);
+        if (predicate(events)) return events;
+        await delay(20);
+    }
+    return readEvents(eventsPath);
+}
+
+function readEvents(eventsPath: string): any[] {
+    try {
+        return readFileSync(eventsPath, 'utf-8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map(line => JSON.parse(line));
+    } catch {
+        return [];
+    }
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+}


### PR DESCRIPTION
## Summary

- Adds bounded cold-start grace policy fields loaded from Interlock laws:
  - `cold_start_grace_requests`
  - `cold_start_grace_ms`
  - `steady_state_latency_threshold_ms`
- Adds runtime phase/grace tracking for Interlock Express.
- Suppresses latency-probe poisoning only for successful bounded cold-start grace requests, while still recording health telemetry and failure signals.
- Stamps health-window and intervention telemetry with runtime phase/grace fields and preserves runtime `law_hash` attribution.
- Extends the local Interlock event schema/types for grace telemetry.
- Adds focused regression coverage for default behavior, request/time expiry, steady-state refusal, failure injection, telemetry stamping, and RESET semantics.

## Evidence basis

Cold-Start Characterization v1 showed the 1900 ms LawPack-backed policy is warm-state useful but cold-start fragile:

- Startup request 1 succeeded but took 3492 ms.
- Startup requests 2-10 false-refused.
- Warm requests 2-10 succeeded after 30 seconds.
- Post-RESET traffic succeeded 10/10.
- SDE validate-log accepted telemetry with 100% stamp coverage.

## Bounded semantics

Grace is active only when both bounds allow it:

- request bound: `cold_start_grace_requests`
- time bound: `cold_start_grace_ms`

Once either bound is exhausted, runtime phase moves to steady state and `steady_state_latency_threshold_ms` applies. Grace does not disable Interlock, does not skip request execution, does not suppress health telemetry, and does not hide failures. Failure injection and severe error signals can still drive refusal during grace.

This does not globally loosen thresholds. It avoids letting a bounded, successful cold-start request poison the latency probe before steady-state evidence exists.

## Reset grace intentionally excluded

Cold-Start Characterization v1 showed post-RESET traffic succeeded 10/10. This PR stamps `post_reset` but does not add reset grace behavior. RESET clears runtime state and then steady-state protection still applies.

## Tests run

- `node .\node_modules\typescript\bin\tsc --noEmit -p tsconfig.ci.json` — passed
- `node .\node_modules\tsx\dist\cli.mjs scripts\validation-tests.ts` — all tests passed
- `node .\node_modules\tsx\dist\cli.mjs scripts\validate-law-loader.ts` — 15 passed, 0 failed
- `node .\node_modules\tsx\dist\cli.mjs scripts\validate-jsonl-schema.ts` — 28 passed, 0 failed
- `node .\node_modules\vitest\vitest.mjs run test\runtimeLawStamp.test.ts test\interlockExpress.control-plane.test.ts test\interlockExpress.cold-start-grace.test.ts` — 12 passed

## Manual proof

Used a temporary law through `INTERLOCK_LAW_PATH` only:

- `latency_threshold_ms = 1900`
- `steady_state_latency_threshold_ms = 1900`
- `cold_start_grace_requests = 1`
- `cold_start_grace_ms = 10000`

Manual local Ollama proof with `gemma3:1b`:

- Startup healthy `/work`: 10/10 succeeded after unloading the model.
- Slow `/work` after grace: first slow request accepted at 2734 ms, next request refused with HTTP 503.
- RESET returned HTTP 200.
- Post-RESET healthy `/work`: 3/3 succeeded.
- Telemetry included `cold_start`, `steady_state`, and `post_reset` phases plus one grace-stamped health-window event.
- SDE validate-log accepted the generated telemetry: VALID, 6/6 parsed, 100% stamp coverage.

## Non-claims

- SDE was not modified.
- No LawPack was promoted, shipped, imported, or mutated.
- This does not claim production readiness.
- This does not claim automatic self-healing.
- This does not prove machine portability or game-domain transfer.